### PR TITLE
Fix for mksi build race condition

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/mksi/CMakeLists.txt
+++ b/GEOSaana_GridComp/GSI_GridComp/mksi/CMakeLists.txt
@@ -14,7 +14,7 @@ ecbuild_add_executable(TARGET make_ozinfo.x SOURCES make_ozinfo.F90 m_oztmpl.F90
 set_target_properties(make_ozinfo.x PROPERTIES Fortran_MODULE_DIRECTORY ${esma_include}/${this})
 ecbuild_add_executable(TARGET make_satinfo.x SOURCES main.F90 m_sitmpl.F90 LIBS ${this})
 set_target_properties(make_satinfo.x PROPERTIES Fortran_MODULE_DIRECTORY ${esma_include}/${this})
-ecbuild_add_executable(TARGET make_pcscaling.x SOURCES pcscaling_main.F90 m_pcscaling.F90 satinfo_util.F90)
+ecbuild_add_executable(TARGET make_pcscaling.x SOURCES pcscaling_main.F90 m_pcscaling.F90 LIBS ${this})
 set_target_properties(make_pcscaling.x PROPERTIES Fortran_MODULE_DIRECTORY ${esma_include}/${this})
 
 install (PROGRAMS gsiinfo.pl DESTINATION bin)


### PR DESCRIPTION
So this is a fun one. In testing the ADAS a while back, @bena-nasa every so often encountered a what looked like a race condition in the build. You'd build it once, it'd fail; build again serially, it worked.

Then, last night, my nightly build of GEOSadas saw this:
```
/discover/nobackup/mathomp4/SystemTests/builds/ADAS/CURRENT/GEOSadas/src/Components/@GEOSana_GridComp/GEOSaana_GridComp/GSI_GridComp/mksi/make_ozinfo.F90(209): error #7013: This module file
was not generated by any release of this compiler.   [SATINFO_UTIL]
  use satinfo_util,only : assert_,warn,tell
------^
```

This was odd since there is only one `satinfo_util` module in the GEOSadas! After consulting with @tclune we found the issue. The `make_pcscaling.x` `add_executable` is asking for `satinfo_util.F90` as a source:
```cmake
ecbuild_add_executable(TARGET make_pcscaling.x SOURCES pcscaling_main.F90 m_pcscaling.F90 satinfo_util.F90)
```
and it is a source, so nothing wrong there! The problem is that if you juuuust happen to build building that module at the same time it's building, say, `make_ozinfo.o` which also uses `satinfo_util` then it could see an "incomplete" modulefile.

It turns out @tclune and @bena-nasa actually figured this out a while back (see https://github.com/GEOS-ESM/GEOSana_GridComp/pull/36/commits/e16759e77b0b1b973a4e502a8de514743e981e43) and created the "libmksi" library to handle it.

So, we just apply the same fix here and make `make_pcscaling.x` depend on libmksi to get `satinfo_util`. 