### PR TITLE
increase array max size to handle current FPP case - should not need …

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/aircraftinfo.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/aircraftinfo.f90
@@ -56,7 +56,7 @@ module aircraftinfo
   logical :: cleanup_tail ! logical to remove tail number no longer used
   logical :: upd_aircraft ! indicator if update bias at 06Z & 18Z
   
-  integer(i_kind), parameter :: max_tail=10000  ! max tail numbers
+  integer(i_kind), parameter :: max_tail=11000  ! max tail numbers
   integer(i_kind) npredt          ! predictor number
   integer(i_kind) ntail           ! total tail number
   integer(i_kind) ntail_update    ! new total tail number


### PR DESCRIPTION
…further increase - the true fix is in the latest DAS scripts default that tells GSI to trim the files on output. This is here to accommodate the present size of the file in FPP for continuation purposes.