### PR TITLE
Add EXTENDED_SOURCE flag for prepbykx.f

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/CMakeLists.txt
+++ b/GEOSaana_GridComp/GSI_GridComp/CMakeLists.txt
@@ -712,6 +712,10 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
    endif ()
 endif ()
 
+if (EXTENDED_SOURCE)
+  set_source_files_properties(prepbykx.f PROPERTIES COMPILE_OPTIONS ${EXTENDED_SOURCE})
+endif ()
+
 set (SRCS_STUBS
   stub_get_wrf_mass_ensperts.f90
   stub_nstmod.f90


### PR DESCRIPTION
This is in part to fix https://github.com/GEOS-ESM/GEOSadas/issues/118 as reported by @bena-nasa. To wit, this PR adds the "extended source" flag when compiling `prepbykx.f` with all build types. We do it for Intel-Release, but not for anything else, like say Intel-Debug. That flag tells the compiler that the source lines might be over 80/132 characters. I think because this is a .f file, that limit might be 80.

By making this change, the GEOSadas `develop` branch can at least *build* with debugging flags on.

Note that this should be trivially zero-diff for the ADAS, but of course @rtodling should confirm.

BONUS! With this, I can add a debug CI build of the ADAS to MAPL. So now every PR to MAPL will build the ADAS. Which is nice. 😄 