### PR TITLE
Knobs for handle Spire RO observations

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi.rc.tmpl
@@ -20,6 +20,7 @@
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.false.,
    use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    lbicg=.true.,lcongrad=.false.,ltlint=.true.,
 !  lsqrtb=.true.,lcongrad=.false.,ltlint=.true.,

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fdda_1.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fdda_1.rc.tmpl
@@ -20,6 +20,7 @@
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.true.,
    use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,nmn_obsbin=@VAROBSBIN,thin4d=.true.,
 !--mPEs_observer=1024   ! obsdiags redistribution upto 0:mPEs_observer-1 files;

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fdda_2.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fdda_2.rc.tmpl
@@ -20,6 +20,7 @@
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.true.,
    use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,nmn_obsbin=@VAROBSBIN,thin4d=.true.,
 !--mPEs_observer=1024   ! obsdiags redistribution upto 0:mPEs_observer-1 files;

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fgat_1.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fgat_1.rc.tmpl
@@ -20,6 +20,7 @@
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.true.,
    use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,nmn_obsbin=@VAROBSBIN,
 !--mPEs_observer=1024   ! obsdiags redistribution upto 0:mPEs_observer-1 files;

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fgat_2.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fgat_2.rc.tmpl
@@ -20,6 +20,7 @@
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.true.,
    use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,nmn_obsbin=@VAROBSBIN,
 !--mPEs_observer=1024   ! obsdiags redistribution upto 0:mPEs_observer-1 files;

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_sens.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_sens.rc.tmpl
@@ -21,6 +21,7 @@
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.false.,
    use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
 !  l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,
 @4DHYB l4densvar=.true.,thin4d=.true.,

--- a/GEOSaana_GridComp/GSI_GridComp/etc/obs.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/obs.rc.tmpl
@@ -21,6 +21,7 @@
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.true.,
    use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    l4dvar=.true.,nhr_assimilation=@VARWINDOW,nmn_obsbin=@VAROBSBIN,
    lobserver=.true.,idmodel=.true.,iwrtinc=@IWRTINC,

--- a/GEOSaana_GridComp/GSI_GridComp/gsimod.F90
+++ b/GEOSaana_GridComp/GSI_GridComp/gsimod.F90
@@ -107,6 +107,7 @@
      jcap_gfs,nlat_gfs,nlon_gfs,jcap_cut,wrf_mass_hybridcord,&
      use_fv3_aero
   use guess_grids, only: ifact10,sfcmod_gfs,sfcmod_mm5,use_compress,nsig_ext,gpstop
+  use guess_grids, only: commgpstop,spiregpserrinf
   use gsi_io, only: init_io,lendian_in,verbose,print_obs_para
   use regional_io_mod, only: regional_io_class
   use wrf_params_mod, only: update_pint, preserve_restart_date
@@ -612,7 +613,7 @@
        diag_tgas, &
        write_diag,reduce_diag, &
        oneobtest,sfcmodel,dtbduv_on,ifact10,offtime_data,&
-       use_pbl,use_compress,nsig_ext,gpstop,&
+       use_pbl,use_compress,nsig_ext,gpstop,commgpstop,spiregpserrinf,&
        perturb_obs,perturb_fact,oberror_tune,preserve_restart_date, &
        crtm_coeffs_path,berror_stats, &
        newpc4pred,adp_anglebc,angord,passive_bc,use_edges,emiss_bc,upd_pred,reset_bad_radbc,&

--- a/GEOSaana_GridComp/GSI_GridComp/guess_grids.F90
+++ b/GEOSaana_GridComp/GSI_GridComp/guess_grids.F90
@@ -142,7 +142,7 @@ module guess_grids
   public :: geop_hgti,ges_lnprsi,ges_lnprsl,geop_hgtl,pbl_height,ges_geopi
   public :: wgt_lcbas
   public :: ges_qsat
-  public :: use_compress,nsig_ext,gpstop
+  public :: use_compress,nsig_ext,gpstop,commgpstop,spiregpserrinf
   public :: ntguesaer,ifileaer,nfldaer,hrdifaer ! variables for external aerosol files
 
   public :: ges_initialized
@@ -225,8 +225,11 @@ module guess_grids
   real(r_kind),allocatable,dimension(:,:,:):: sno2  ! sno depth on subdomain
 
 
-  real(r_kind):: gpstop=30.0_r_kind   ! maximum gpsro height used in km 
-                                      ! geometric height for ref, impact height for bnd
+  real(r_kind):: gpstop=30.0_r_kind        ! maximum gpsro height used in km 
+                                           ! geometric height for ref, impact height for bnd
+  real(r_kind):: spiregpserrinf=1.0_r_kind ! SPIRE ob error inflation factor
+  real(r_kind):: commgpstop=30.0_r_kind    ! maximum SPIRE RO height used in km 
+                                           ! geometric height for ref, impact height for bnd
 
   real(r_kind):: ges_psfcavg                            ! average guess surface pressure 
   real(r_kind),allocatable,dimension(:):: ges_prslavg   ! average guess pressure profile

--- a/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
@@ -148,12 +148,14 @@ subroutine setupbend(obsLL,odiagLL, &
   use gsi_4dvar, only: nobs_bins,mn_obsbin
   use guess_grids, only: ges_lnprsi,hrdifsig,geop_hgti,nfldsig
   use guess_grids, only: nsig_ext,gpstop
+  use guess_grids, only: commgpstop,spiregpserrinf
   use guess_grids, only: ges_lnprsl,geop_hgtl 
   use gridmod, only: nsig
   use gridmod, only: get_ij,latlon11
   use constants, only: fv,n_a,n_b,n_c,deg2rad,tiny_r_kind,r0_01,r18,r61,r63,r10000
   use constants, only: zero,half,one,two,eccentricity,semi_major_axis,&
       grav_equator,somigliana,flattening,grav_ratio,grav,rd,eps,three,four,five
+  use constants, only: r100,r400
   use lagmod, only: setq, setq_TL
   use lagmod, only: slagdw, slagdw_TL
   use jfunc, only: jiter,miter,jiterstart
@@ -258,6 +260,8 @@ subroutine setupbend(obsLL,odiagLL, &
   logical proceed
   logical geooptics
   logical planetiq
+  logical spire
+  logical commdat
 
   logical:: in_curbin, in_anybin, obs_check,qc_layer_SR, save_jacobian
   type(gpsNode),pointer:: my_head
@@ -605,6 +609,7 @@ subroutine setupbend(obsLL,odiagLL, &
 
      geooptics = data(isatid,i)==265 .or. data(isatid,i)==266
      planetiq  = data(isatid,i)==267 .or. data(isatid,i)==268
+     spire     = data(isatid,i)==269
      if(ratio_errors(i) > tiny_r_kind)  then ! obs inside model grid
 
        if (alt <= six) then
@@ -720,6 +725,11 @@ subroutine setupbend(obsLL,odiagLL, &
 
          repe_gps=exp(repe_gps) ! one/modified error in (rad-1*1E3)
          repe_gps= r1em3*(one/abs(repe_gps)) ! modified error in rad
+         commdat=.false.
+         if (spire) then
+             repe_gps=spiregpserrinf*repe_gps ! Inflate error for SPIRE data
+         endif
+         commdat = spire.or.geooptics.or.planetiq
          ratio_errors(i) = data(ier,i)/abs(repe_gps)
   
          error(i)=one/data(ier,i) ! one/original error
@@ -817,75 +827,87 @@ subroutine setupbend(obsLL,odiagLL, &
 
          if (alt <= gpstop) then ! go into qc checks
 
-!           Gross error check
-            obserror = one/max(ratio_errors(i)*data(ier,i),tiny_r_kind)
-            obserrlm = max(cermin(ikx),min(cermax(ikx),obserror))
-            residual = abs(data(igps,i))
-            ratio    = residual/obserrlm
+           if ((alt <= commgpstop) .or. (.not.commdat)) then 
+              cgrossuse=cgross(ikx)
+              cermaxuse=cermax(ikx)
+              cerminuse=cermin(ikx) 
+! These lines introduce untested non-zero diff; comment for now (Todling)
+!!_RT         if (alt > five) then
+!!_RT            cgrossuse=cgrossuse*r400
+!!_RT            cermaxuse=cermaxuse*r400
+!!_RT            cerminuse=cerminuse*r100
+!!_RT         endif
 
-            if (ratio > cgross(ikx)) then
-                if (luse(i)) then
-                   awork(4) = awork(4)+one
-                endif
-                qcfail_gross(i)=one 
-                data(ier,i) = zero
-                ratio_errors(i) = zero
-                muse(i)=.false.
-            else   
-!               Statistics QC check if obs passed gross error check
-                cutoff=zero
-                if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
-                   cutoff1=(-4.725_r_kind+0.045_r_kind*alt+0.005_r_kind*alt**2)*one/two
-                else
-                   cutoff1=(-4.725_r_kind+0.045_r_kind*alt+0.005_r_kind*alt**2)*two/three
-                end if
-                cutoff2=1.5_r_kind+one*cos(data(ilate,i)*deg2rad)
-                if(trefges<=r240) then
-                   cutoff3=two
-                else
-                   cutoff3=0.005_r_kind*trefges**2-2.3_r_kind*trefges+266_r_kind
-                endif
-                if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
-                   cutoff3=cutoff3*one/two
-                else
-                   cutoff3=cutoff3*two/three
-                end if
-                if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
-                   cutoff4=(four+eight*cos(data(ilate,i)*deg2rad))*one/two
-                else
-                   cutoff4=(four+eight*cos(data(ilate,i)*deg2rad))*two/three
-                end if
-                cutoff12=((36_r_kind-alt)/two)*cutoff2+&
-                         ((alt-34_r_kind)/two)*cutoff1
-                cutoff23=((eleven-alt)/two)*cutoff3+&
-                         ((alt-nine)/two)*cutoff2
-                cutoff34=((six-alt)/two)*cutoff4+&
-                         ((alt-four)/two)*cutoff3
-                if(alt>36_r_kind) cutoff=cutoff1
-                if((alt<=36_r_kind).and.(alt>34_r_kind)) cutoff=cutoff12
-                if((alt<=34_r_kind).and.(alt>eleven)) cutoff=cutoff2
-                if((alt<=eleven).and.(alt>nine)) cutoff=cutoff23
-                if((alt<=nine).and.(alt>six)) cutoff=cutoff3
-                if((alt<=six).and.(alt>four)) cutoff=cutoff34
-                if(alt<=four) cutoff=cutoff4
+!             Gross error check
+              obserror = one/max(ratio_errors(i)*data(ier,i),tiny_r_kind)
+              obserrlm = max(cerminuse,min(cermaxuse,obserror))
+              residual = abs(data(igps,i))
+              ratio    = residual/obserrlm
 
-                if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
-                   cutoff=two*cutoff*r0_01
-                else
-                   cutoff=three*cutoff*r0_01
-                end if
+              if (ratio > cgrossuse) then
+                  if (luse(i)) then
+                     awork(4) = awork(4)+one
+                  endif
+                  qcfail_gross(i)=one 
+                  data(ier,i) = zero
+                  ratio_errors(i) = zero
+                  muse(i)=.false.
+              else   
+!                 Statistics QC check if obs passed gross error check
+                  cutoff=zero
+                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
+                     cutoff1=(-4.725_r_kind+0.045_r_kind*alt+0.005_r_kind*alt**2)*one/two
+                  else
+                     cutoff1=(-4.725_r_kind+0.045_r_kind*alt+0.005_r_kind*alt**2)*two/three
+                  end if
+                  cutoff2=1.5_r_kind+one*cos(data(ilate,i)*deg2rad)
+                  if(trefges<=r240) then
+                     cutoff3=two
+                  else
+                     cutoff3=0.005_r_kind*trefges**2-2.3_r_kind*trefges+266_r_kind
+                  endif
+                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
+                     cutoff3=cutoff3*one/two
+                  else
+                     cutoff3=cutoff3*two/three
+                  end if
+                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
+                     cutoff4=(four+eight*cos(data(ilate,i)*deg2rad))*one/two
+                  else
+                     cutoff4=(four+eight*cos(data(ilate,i)*deg2rad))*two/three
+                  end if
+                  cutoff12=((36_r_kind-alt)/two)*cutoff2+&
+                           ((alt-34_r_kind)/two)*cutoff1
+                  cutoff23=((eleven-alt)/two)*cutoff3+&
+                           ((alt-nine)/two)*cutoff2
+                  cutoff34=((six-alt)/two)*cutoff4+&
+                           ((alt-four)/two)*cutoff3
+                  if(alt>36_r_kind) cutoff=cutoff1
+                  if((alt<=36_r_kind).and.(alt>34_r_kind)) cutoff=cutoff12
+                  if((alt<=34_r_kind).and.(alt>eleven)) cutoff=cutoff2
+                  if((alt<=eleven).and.(alt>nine)) cutoff=cutoff23
+                  if((alt<=nine).and.(alt>six)) cutoff=cutoff3
+                  if((alt<=six).and.(alt>four)) cutoff=cutoff34
+                  if(alt<=four) cutoff=cutoff4
+  
+                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
+                     cutoff=two*cutoff*r0_01
+                  else
+                     cutoff=three*cutoff*r0_01
+                  end if
  
-                if(abs(rdiagbuf(5,i)) > cutoff) then
-                   qcfail(i)=.true.
-                   data(ier,i) = zero
-                   ratio_errors(i) = zero
-                   muse(i) = .false.
-                end if
-            end if ! gross qc check
+                  if(abs(rdiagbuf(5,i)) > cutoff) then
+                     qcfail(i)=.true.
+                     data(ier,i) = zero
+                     ratio_errors(i) = zero
+                     muse(i) = .false.
+                  end if
+              end if ! gross qc check
+            end if ! commercial data
          end if ! qc checks (only below 50km)
 
 !        Remove obs above 50 km  
-         if(alt > gpstop) then
+         if((alt > gpstop) .or. (commdat .and. (alt > commgpstop))) then
            data(ier,i) = zero
            ratio_errors(i) = zero
            qcfail_high(i)=one


### PR DESCRIPTION
This adds minimal adjustments to properly handle Spire data - will need change in fvsetup set nsig_ext from 15 to 18. The changes here do not trigger SPIRE automatically - convinfo not changed. The changes are zero diff to 5.29.4.