### PR TITLE
Edits for creating UFO test files and AMV updates in x0045.

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/analyzer
+++ b/GEOSaana_GridComp/GSI_GridComp/analyzer
@@ -645,8 +645,7 @@ sub init {
    if ( $ENV{CRTM_COEFFS} ) {
       Assignfn( "$CRTM_COEFFS","CRTM_Coeffs");
    } else {
-#     Assignfn( "$fvInput/$myetc/fix_ncep20200513/REL-2.2.3-r60152_local-rev_4/CRTM_Coeffs/Little_Endian","CRTM_Coeffs");
-      Assignfn( "$fvInput/$myetc/fix_ncep20210525/REL-2.2.3-r60152_local-rev_5/CRTM_Coeffs/Little_Endian","CRTM_Coeffs");
+      Assignfn( "$fvInput/$myetc/fix_ncep20200513/REL-2.2.3-r60152_local-rev_4/CRTM_Coeffs/Little_Endian","CRTM_Coeffs");
    }
    Assignfn( "$fvhome/run/prepobs_errtable.global","errtable");
 

--- a/GEOSaana_GridComp/GSI_GridComp/analyzer
+++ b/GEOSaana_GridComp/GSI_GridComp/analyzer
@@ -645,7 +645,8 @@ sub init {
    if ( $ENV{CRTM_COEFFS} ) {
       Assignfn( "$CRTM_COEFFS","CRTM_Coeffs");
    } else {
-      Assignfn( "$fvInput/$myetc/fix_ncep20200513/REL-2.2.3-r60152_local-rev_4/CRTM_Coeffs/Little_Endian","CRTM_Coeffs");
+#     Assignfn( "$fvInput/$myetc/fix_ncep20200513/REL-2.2.3-r60152_local-rev_4/CRTM_Coeffs/Little_Endian","CRTM_Coeffs");
+      Assignfn( "$fvInput/$myetc/fix_ncep20210525/REL-2.2.3-r60152_local-rev_5/CRTM_Coeffs/Little_Endian","CRTM_Coeffs");
    }
    Assignfn( "$fvhome/run/prepobs_errtable.global","errtable");
 

--- a/GEOSaana_GridComp/GSI_GridComp/genstats_gps.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/genstats_gps.f90
@@ -53,6 +53,13 @@ module m_gpsStats
       real(r_kind)    :: b                      
       real(r_kind)    :: loc                    
       real(r_kind)    :: type               
+      real(r_kind),dimension(:),pointer :: tsenges
+      real(r_kind),dimension(:),pointer :: tvirges
+      real(r_kind),dimension(:),pointer :: sphmges
+      real(r_kind),dimension(:),pointer :: hgtlges
+      real(r_kind),dimension(:),pointer :: hgtiges
+      real(r_kind),dimension(:),pointer :: prsiges
+      real(r_kind),dimension(:),pointer :: prslges
 
       real(r_kind),dimension(:),pointer :: rdiag => NULL()
       real(r_kind),dimension(10)        :: rdiag_extra_val
@@ -746,6 +753,12 @@ subroutine init_netcdf_diag_
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )
+        if (save_jacobian) then
+          nnz   = 3*nsig
+          nind  = 3
+          call nc_diag_header("jac_nnz", nnz)
+          call nc_diag_header("jac_nind", nind)
+        endif
      endif
 end subroutine init_netcdf_diag_
 
@@ -753,6 +766,8 @@ subroutine contents_binary_diag_
 end subroutine contents_binary_diag_
 
 subroutine contents_netcdf_diag_
+! 2021-03-26 H. Zhang  - output metadata 2d geovals for JEDI
+
   use sparsearr, only: sparr2, readarray, fullarray
   integer(i_kind),dimension(miter) :: obsdiag_iuse
   integer(i_kind)                  :: obstype, obssubtype
@@ -761,6 +776,17 @@ subroutine contents_netcdf_diag_
 ! Observation class
   character(7),parameter     :: obsclass = '    gps'
 
+!          geovals
+!!         call nc_diag_metadata("surface_pressure",sngl(psges*r1000))
+           call nc_diag_metadata("surface_geopotential_height",sngl(gps_allptr%rdiag(9)) )
+           call nc_diag_data2d("air_temperature",             sngl(gps_allptr%tsenges) )
+           call nc_diag_data2d("virtual_temperature",         sngl(gps_allptr%tvirges) )
+           call nc_diag_data2d("specific_humidity",           sngl(gps_allptr%sphmges) )
+           call nc_diag_data2d("geopotential_height",         sngl(gps_allptr%hgtlges) )
+           call nc_diag_data2d("geopotential_height_levels",  sngl(gps_allptr%hgtiges) )
+           call nc_diag_data2d("atmosphere_pressure_coordinate_interface",  sngl(gps_allptr%prsiges) )
+           call nc_diag_data2d("atmosphere_pressure_coordinate",            sngl(gps_allptr%prslges) )
+!
            call nc_diag_metadata("Station_ID",                            gps_allptr%cdiag             )
            call nc_diag_metadata("Observation_Class",                     obsclass                     )
            obstype    = gps_allptr%rdiag(1) 
@@ -785,6 +811,8 @@ subroutine contents_netcdf_diag_
            call nc_diag_metadata("Observation",                           sngl(gps_allptr%rdiag(17))   )
            call nc_diag_metadata("Obs_Minus_Forecast_adjusted",           sngl(gps_allptr%rdiag(17))*sngl(gps_allptr%rdiag(5)) )
            call nc_diag_metadata("Obs_Minus_Forecast_unadjusted",         sngl(gps_allptr%rdiag(17))*sngl(gps_allptr%rdiag(5)) )
+           call nc_diag_metadata("Forecast_adjusted", sngl(gps_allptr%rdiag(17)-(gps_allptr%rdiag(17)*gps_allptr%rdiag(5))))
+           call nc_diag_metadata("Forecast_unadjusted", sngl(gps_allptr%rdiag(17)-(gps_allptr%rdiag(17)*gps_allptr%rdiag(5))))
            call nc_diag_metadata("GPS_Type",                              sngl(gps_allptr%rdiag(20))   )
            call nc_diag_metadata("Vertical_Grid_Location",                sngl(gps_allptr%rdiag(19))   )
            call nc_diag_metadata("Temperature_at_Obs_Location",           sngl(gps_allptr%rdiag(18))   )
@@ -794,6 +822,9 @@ subroutine contents_netcdf_diag_
               call readarray(dhx_dx, gps_allptr%rdiag(ioff+1:nreal))
               call fullarray(dhx_dx, dhx_dx_array)
               call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+              call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind(1:dhx_dx%nind))
+              call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind(1:dhx_dx%nind))
+              call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val(1:dhx_dx%nnz),r_single))
            endif
 
            do i=1, gps_allptr%n_rdiag_extra

--- a/GEOSaana_GridComp/GSI_GridComp/gsi_io.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/gsi_io.f90
@@ -76,8 +76,7 @@ contains
 !   Set unit numbers reserved for little endian input and output
     lendian_in  = 15
     lendian_out = 66
-!    verbose = .false.
-    verbose = .true.   !jjj, 04/18/2022
+    verbose = .false.
     print_obs_para = .false.
 
     if (mype==0) write(6,*)'INIT_IO:  reserve units lendian_in=',lendian_in,&

--- a/GEOSaana_GridComp/GSI_GridComp/gsi_io.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/gsi_io.f90
@@ -76,7 +76,8 @@ contains
 !   Set unit numbers reserved for little endian input and output
     lendian_in  = 15
     lendian_out = 66
-    verbose = .false.
+!    verbose = .false.
+    verbose = .true.   !jjj, 04/18/2022
     print_obs_para = .false.
 
     if (mype==0) write(6,*)'INIT_IO:  reserve units lendian_in=',lendian_in,&

--- a/GEOSaana_GridComp/GSI_GridComp/gsimod.F90
+++ b/GEOSaana_GridComp/GSI_GridComp/gsimod.F90
@@ -71,7 +71,7 @@
       erradar_inflate,tdrerr_inflate,use_poq7,qc_satwnds,&
       init_qcvars,vadfile,noiqc,c_varqc,qc_noirjaco3,qc_noirjaco3_pole,&
       buddycheck_t,buddydiag_save,njqc,vqc,vadwnd_l2rw_qc, &
-      pvis,pcldch,scale_cv,estvisoe,estcldchoe,vis_thres,cldch_thres,cao_check
+      pvis,pcldch,scale_cv,estvisoe,estcldchoe,vis_thres,cldch_thres,cao_check,half_goesr_err
   use pcpinfo, only: npredp,diag_pcp,dtphys,deltim,init_pcp
   use jfunc, only: iout_iter,iguess,miter,factqmin,factqmax, &
      factql,factqi,factqr,factqs,factqg, &  
@@ -822,6 +822,7 @@
 !     qc_noirjaco3 - controls whether to use O3 Jac from IR instruments
 !     qc_noirjaco3_pole - controls wheter to use O3 Jac from IR instruments near poles
 !     qc_satwnds - allow bypass sat-winds qc normally removing lots of mid-tropo obs
+!     half_goesr_err - .t., hack GOES-R errors and half them
 !     aircraft_t_bc_pof  - logical for aircraft temperature bias correction, pof
 !                          is used for predictor
 !     aircraft_t_bc  - logical for aircraft temperature bias correction
@@ -847,7 +848,7 @@
        tcp_ermin,tcp_ermax,qc_noirjaco3,qc_noirjaco3_pole,qc_satwnds,njqc,vqc,&
        aircraft_t_bc_pof,aircraft_t_bc,aircraft_t_bc_ext,biaspredt,upd_aircraft,cleanup_tail,&
        hdist_aircraft,buddycheck_t,buddydiag_save,vadwnd_l2rw_qc,  &
-       pvis,pcldch,scale_cv,estvisoe,estcldchoe,vis_thres,cldch_thres,cld_det_dec2bin
+       pvis,pcldch,scale_cv,estvisoe,estcldchoe,vis_thres,cldch_thres,cld_det_dec2bin,half_goesr_err
 
 ! OBS_INPUT (controls input data):
 !      dmesh(max(dthin))- thinning mesh for each group

--- a/GEOSaana_GridComp/GSI_GridComp/qcmod.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/qcmod.f90
@@ -170,6 +170,7 @@ module qcmod
   public :: qc_noirjaco3
   public :: qc_noirjaco3_pole
   public :: qc_satwnds
+  public :: half_goesr_err
   public :: qc_gmi
   public :: qc_amsr2
   public :: qc_saphir
@@ -196,6 +197,7 @@ module qcmod
   logical newvad
   logical tdrerr_inflate
   logical qc_satwnds
+  logical half_goesr_err
   logical buddycheck_t
   logical buddydiag_save
   logical vadwnd_l2rw_qc
@@ -386,6 +388,7 @@ contains
 !   2012-07-19  todling - add qc_satwnds to allow bypass of satwind qc
 !   2013-10-27  todling - move alloc space to create_qcvars
 !   2014-10-06  carley - add logicals for buddy check
+!   2021-06-21  todling - add half_goesr_err to bypass hack halving GEOS-R errors
 !
 !   input argument list:
 !
@@ -422,6 +425,7 @@ contains
     qc_noirjaco3_pole = .false. ! true=do not use O3 Jac from IR instruments near poles
 
     qc_satwnds=.true. ! default: remove lots of SatWind at mid-tropospheric levels
+    half_goesr_err=.true.  ! default: consistent w/ NCEP''s choice - ie, use hack
 
     buddycheck_t=.false.   ! When true, run buddy check algorithm on temperature observations
     buddydiag_save=.false. ! When true, output files containing buddy check QC info for all

--- a/GEOSaana_GridComp/GSI_GridComp/read_fl_hdob.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/read_fl_hdob.f90
@@ -56,6 +56,7 @@ subroutine read_fl_hdob(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,si
          ithin_conv,rmesh_conv,pmesh_conv
      use obsmod, only: perturb_obs,perturb_fact,ran01dom
      use obsmod, only: bmiss
+     use aircraftinfo, only: aircraft_t_bc,aircraft_t_bc_pof,aircraft_t_bc_ext
      use converr,only: etabl
      use converr_ps,only: etabl_ps,isuble_ps,maxsub_ps
      use converr_q,only: etabl_q,isuble_q,maxsub_q
@@ -238,10 +239,11 @@ subroutine read_fl_hdob(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,si
      iecol=0
      if (ltob) then
         nreal  = 25
+        if (aircraft_t_bc_pof .or. aircraft_t_bc .or.aircraft_t_bc_ext) nreal=nreal+3
         iecol  =  2 
         errmin = half      ! set lower bound of ob error for T or Tv
      else if (luvob) then
-        nreal  = 25
+        nreal  = 26
         iecol  =  4  
         errmin = one       ! set lower bound of ob error for u,v winds
      else if (lspdob) then
@@ -533,6 +535,7 @@ subroutine read_fl_hdob(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,si
                write(6,*) 'READ_FL_HDOB: bad lat/lon values: ', obsloc(1,1),obsloc(2,1)              
                cycle loop_readsb2     
            endif
+           if (obsloc(2,1) < 0.0_r_kind) obsloc(2,1) = obsloc(2,1) + 360.0_r_kind
            dlon_earth_deg = obsloc(2,1)
            dlat_earth_deg = obsloc(1,1)
            dlon_earth = obsloc(2,1)*deg2rad ! degree to radian
@@ -1035,6 +1038,7 @@ subroutine read_fl_hdob(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,si
               cdata_all(23,iout)=r_sprvstg(1,1)         ! subprovider name
               cdata_all(24,iout)=qcm                    ! cat
               cdata_all(25,iout)=var_jb                 ! non linear qc 
+              cdata_all(26,iout)=one
               if(perturb_obs)then
                  cdata_all(26,iout)=ran01dom()*perturb_fact ! u perturbation
                  cdata_all(27,iout)=ran01dom()*perturb_fact ! v perturbation

--- a/GEOSaana_GridComp/GSI_GridComp/read_gps.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/read_gps.f90
@@ -100,7 +100,7 @@ subroutine read_gps(nread,ndata,nodata,infile,lunout,obstype,twind, &
 
 ! Declare local parameters  
   integer(i_kind),parameter:: maxlevs=500
-  integer(i_kind),parameter:: maxinfo=18
+  integer(i_kind),parameter:: maxinfo=22
   real(r_kind),parameter:: r10000=10000.0_r_kind
   real(r_kind),parameter:: r360=360.0_r_kind
 
@@ -114,6 +114,7 @@ subroutine read_gps(nread,ndata,nodata,infile,lunout,obstype,twind, &
 
   
   integer(i_kind) lnbufr,i,k,m,maxobs,ireadmg,ireadsb,said,ptid
+  integer(i_kind) siid,sclf,ogce,ascd
   integer(i_kind) nmrecs
   integer(i_kind) notgood,idate
   integer(i_kind) iret,levs,levsr,nreps_ROSEQ1,mincy,minobs
@@ -132,18 +133,19 @@ subroutine read_gps(nread,ndata,nodata,infile,lunout,obstype,twind, &
   real(r_kind) pcc,qfro,usage,dlat,dlat_earth,dlon,dlon_earth,freq_chk,freq
   real(r_kind) dlat_earth_deg,dlon_earth_deg
   real(r_kind) height,rlat,rlon,ref,bend,impact,roc,geoid,&
-               bend_error,ref_error,bend_pccf,ref_pccf,sclf,qfro_init
+               bend_error,ref_error,bend_pccf,ref_pccf, azim,qfro_init
 
   real(r_kind),allocatable,dimension(:,:):: cdata_all
  
-  integer(i_kind),parameter:: n1ahdr=11
+  integer(i_kind),parameter:: n1ahdr=13
   real(r_double),dimension(n1ahdr):: bfr1ahdr
   real(r_double),dimension(50,maxlevs):: data1b
   real(r_double),dimension(50,maxlevs):: data2a
   real(r_double),dimension(maxlevs):: nreps_this_ROSEQ2
  
   data lnbufr/10/
-  data hdr1a / 'YEAR MNTH DAYS HOUR MINU PCCF ELRC SAID PTID GEODU SCLF' / 
+! 
+  data hdr1a / 'YEAR MNTH DAYS HOUR MINU PCCF ELRC SAID SIID PTID GEODU SCLF OGCE'/ 
   data nemo /'QFRO'/
   
 !***********************************************************************************
@@ -221,9 +223,11 @@ subroutine read_gps(nread,ndata,nodata,infile,lunout,obstype,twind, &
         pcc=bfr1ahdr(6)         ! profile per cent confidence
         roc=bfr1ahdr(7)         ! Earth local radius of curvature
         said=bfr1ahdr(8)        ! Satellite identifier
-        ptid=bfr1ahdr(9)        ! Platform transmitter ID number
-        geoid=bfr1ahdr(10)      ! Geoid undulation
-        sclf=bfr1ahdr(11)         ! Satellite Classification (tranmitter type)
+        siid = bfr1ahdr(9)        ! Satellite instrument
+        ptid = bfr1ahdr(10)       ! Platform transmitter ID number
+        geoid= bfr1ahdr(11)       ! Geoid undulation
+        sclf = bfr1ahdr(12)       ! GNSS satellite classification
+        ogce = bfr1ahdr(13)       ! Identification of originating/generating centre
         call w3fs21(idate5,minobs)
 
 ! Locate satellite id in convinfo file
@@ -294,6 +298,18 @@ subroutine read_gps(nread,ndata,nodata,infile,lunout,obstype,twind, &
            endif
         endif
 
+! read profile ascending flag 1=ascending
+        ascd = 0
+        call upftbv(lnbufr,nemo,qfro,mxib,ibit,nib)
+        if(nib > 0) then
+           do i=1,nib
+              if(ibit(i)== 3) then
+                 ascd = 1
+! j.jin. 07/08/2022. 
+!                 exit
+              endif
+           enddo
+        endif
 
 ! Read bending angle information
 ! Get the number of occurences of sequence ROSEQ2 in this subset
@@ -343,6 +359,7 @@ subroutine read_gps(nread,ndata,nodata,infile,lunout,obstype,twind, &
            nread=nread+1  ! count observations
            rlat=data1b(1,k)  ! earth relative latitude (degrees)
            rlon=data1b(2,k)  ! earth relative longitude (degrees)
+           azim=data1b(3,k)  ! LEO azimuth angle
            height=data2a(1,k)
            ref=data2a(2,k)
            ref_error=data2a(4,k)
@@ -438,8 +455,12 @@ subroutine read_gps(nread,ndata,nodata,infile,lunout,obstype,twind, &
               cdata_all(14,ndata)= dlon_earth_deg  ! earth relative longitude (degrees)
               cdata_all(15,ndata)= dlat_earth_deg  ! earth relative latitude (degrees)
               cdata_all(16,ndata)= geoid           ! geoid undulation (m)
-              cdata_all(17,ndata)= sclf              ! sat classification
-              cdata_all(18,ndata)= qfro_init    ! initial quality flag
+              cdata_all(17,ndata)= sclf            ! GNSS satellite classification
+              cdata_all(18,ndata)= siid            ! LEO Satellite instrument
+              cdata_all(19,ndata)= ascd            ! ascending/descending flag
+              cdata_all(20,ndata)= ogce            ! Identification of originating/generating
+              cdata_all(21,ndata)= azim            ! LEO azimuth angle
+              cdata_all(22,ndata)= qfro_init    ! initial quality flag
               
            else
               notgood = notgood + 1

--- a/GEOSaana_GridComp/GSI_GridComp/read_satwnd.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/read_satwnd.f90
@@ -97,7 +97,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
   use kinds, only: r_kind,r_double,i_kind,r_single
   use gridmod, only: diagnostic_reg,regional,nlon,nlat,nsig,&
        tll2xy,txy2ll,rotate_wind_ll2xy,rotate_wind_xy2ll,&
-       rlats,rlons,twodvar_regional,wrf_nmm_regional
+       rlats,rlons,twodvar_regional,wrf_nmm_regional,fv3_regional
   use qcmod, only: errormod,njqc
   use qcmod, only: half_goesr_err
   use convthin, only: make3grids,map3grids,map3grids_m,del3grids,use_all
@@ -264,7 +264,8 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
 ! Set lower limits for observation errors
   werrmin=one
   nsattype=0
-  nreal=25
+! nreal=26
+ nreal=30
   if(perturb_obs ) nreal=nreal+2
   ntread=1
   ntmatch=0
@@ -327,7 +328,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
         endif
 
             
-           call ufbint(lunin,hdrdat,13,1,iret,hdrtr_v1) 
+        call ufbint(lunin,hdrdat,13,1,iret,hdrtr_v1) 
           ! SWQM doesn't exist for GOES-R/new BUFR/ hence hdrdat(13)=MISSING.
           ! qm=2, instead of using hdrdat(13)(2015-07-16, Genkova)
 
@@ -344,22 +345,22 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
               else if(hdrdat(9) == three) then            ! WV cloud top
                  itype=254
               else if(hdrdat(9) >= four) then             ! WV deep layer, monitored
-                itype=254
+                 itype=254
               endif
            endif
         else if(trim(subset) == 'NC005067' .or. trim(subset) == 'NC005068' .or.&
                 trim(subset) == 'NC005069') then               ! read new EUM BURF
-             if( hdrdat(1) <r80 .and. hdrdat(1) >= r50) then   !the range of EUMETSAT satellite IDS
-                if(hdrdat(9) == one)  then                  ! IR winds
-                   itype=253
-                else if(hdrdat(9) == two) then              ! visible winds
-                   itype=243
-                else if(hdrdat(9) == three) then            ! WV cloud top
-                   itype=254
-                else if(hdrdat(9) >= four) then             ! WV deep layer, monitored 
-                   itype=254
-                endif
-             endif   
+           if( hdrdat(1) <r80 .and. hdrdat(1) >= r50) then   !the range of EUMETSAT satellite IDS
+              if(hdrdat(9) == one)  then                  ! IR winds
+                 itype=253
+              else if(hdrdat(9) == two) then              ! visible winds
+                 itype=243
+              else if(hdrdat(9) == three) then            ! WV cloud top
+                 itype=254
+              else if(hdrdat(9) >= four) then             ! WV deep layer, monitored 
+                 itype=254
+              endif
+           endif
         else if(trim(subset) == 'NC005044' .or. trim(subset) == 'NC005045' .or. &
            trim(subset) == 'NC005046') then
            if( hdrdat(1) >=r100 .and. hdrdat(1) <=r199 ) then   ! the range of JMA satellite IDS
@@ -430,9 +431,11 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
         !          itype=260
         !       endif
 !Temporary solution replacing the commented code above
-                 if(trim(subset) == 'NC005091')  then                 ! IR LW winds
-                    itype=260
-                 endif
+           if(trim(subset) == 'NC005091')  then                 ! IR LW winds
+              itype=260
+           endif
+
+
         !GOES-R section of the 'if' statement over 'subsets' 
         else if(trim(subset) == 'NC005030' .or. trim(subset) == 'NC005031' .or. trim(subset) == 'NC005032' .or. &
                 trim(subset) == 'NC005034' .or. trim(subset) == 'NC005039') then
@@ -453,17 +456,17 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
 !                 endif
 
 !Temporary solution replacing the commented code above
-                 if(trim(subset) == 'NC005030')  then                 ! IR LW winds
-                    itype=245
-                 else if(trim(subset) == 'NC005039')  then            ! IR SW winds
-                    itype=240                                      
-                 else if(trim(subset) == 'NC005032')  then            ! VIS winds
-                    itype=251
-                 else if(trim(subset) == 'NC005034')  then            ! WV cloud top
-                    itype=246
-                 else if(trim(subset) == 'NC005031')  then            ! WV clear sky/deep layer
-                    itype=247
-                 endif
+           if(trim(subset) == 'NC005030')  then                 ! IR LW winds
+              itype=245
+           else if(trim(subset) == 'NC005039')  then            ! IR SW winds
+              itype=240                                      
+           else if(trim(subset) == 'NC005032')  then            ! VIS winds
+              itype=251
+           else if(trim(subset) == 'NC005034')  then            ! WV cloud top
+              itype=246
+           else if(trim(subset) == 'NC005031')  then            ! WV clear sky/deep layer
+              itype=247
+           endif
         endif ! end of if-then-endif over NC* subsets
 
 !  Match ob to proper convinfo type
@@ -602,13 +605,13 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
 
 !          Test for BUFR version using lat/lon mnemonics
            call ufbint(lunin,hdrdat_test,2,1,iret, 'CLAT CLON')
-          if ( hdrdat_test(1) > 100000000.0_r_kind .and. hdrdat_test(2) > 100000000.0_r_kind ) then
-           call ufbint(lunin,hdrdat,13,1,iret,hdrtr_v2) 
-           call ufbint(lunin,obsdat,4,1,iret,obstr_v2)
-          else
-           call ufbint(lunin,hdrdat,13,1,iret,hdrtr_v1) 
-           call ufbint(lunin,obsdat,4,1,iret,obstr_v1)
-          endif
+           if ( hdrdat_test(1) > 100000000.0_r_kind .and. hdrdat_test(2) > 100000000.0_r_kind ) then
+              call ufbint(lunin,hdrdat,13,1,iret,hdrtr_v2) 
+              call ufbint(lunin,obsdat,4,1,iret,obstr_v2)
+           else
+              call ufbint(lunin,hdrdat,13,1,iret,hdrtr_v1) 
+              call ufbint(lunin,obsdat,4,1,iret,obstr_v1)
+           endif
 
            ppb=obsdat(2)
            if (ppb > 100000000.0_r_kind .or. &
@@ -686,7 +689,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                  enddo
                  if(qifn <85.0_r_kind )  then    !  qifn, QI without forecast
                     qm=15
-                 endif 
+                 endif
               endif
            else if(trim(subset) == 'NC005044' .or. trim(subset) == 'NC005045' .or. &   ! JMA
                    trim(subset) == 'NC005046') then           
@@ -722,12 +725,13 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                           qifn=qcdat(3,j)
                        else if(qcdat(2,j) == 103.0_r_kind .and. ee >r105) then
                           ee=qcdat(3,j)
-                       endif   
+                       endif
                     endif
-                 enddo 
+                 enddo
+                 
                  if(qifn <85.0_r_kind )  then     ! qifn: QI value without forecast 
                     qm=15
-                 endif 
+                 endif
               endif
            else if(trim(subset) == 'NC005010' .or. trim(subset) == 'NC005011' .or. &  ! NESDIS GOES 
                    trim(subset) == 'NC005012' ) then
@@ -753,7 +757,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                     c_station_id='WV'//stationid
                     c_sprvstg='WV'
                  else if(hdrdat(9) >= four) then                       ! WV deep layer.mornitored set in convinfo file
-                     itype=247
+                    itype=247
                     c_station_id='WV'//stationid
                     c_sprvstg='WV'
                  endif
@@ -768,7 +772,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                           qify=qcdat(3,j)
                        else if( qcdat(2,j) == four .and. ee >r105) then
                           ee=qcdat(3,j) 
-                       endif  
+                       endif
                     endif
                  enddo
 !QI not applied to CAWV for now - may in the future
@@ -821,7 +825,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                           qify=qcdat(3,j)
                        else if( qcdat(2,j) == four .and. ee >r105 ) then
                           ee=qcdat(3,j) 
-                       endif  
+                       endif
                     endif
                  enddo
               endif
@@ -845,7 +849,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                           qify=qcdat(3,j)
                        else if( qcdat(2,j) == four .and. ee >r105) then
                           ee=qcdat(3,j)
-                       endif 
+                       endif
                     endif
                  enddo
               endif
@@ -878,7 +882,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                  endif
               endif
            else if( trim(subset) == 'NC005090') then                   ! VIIRS IR winds 
-               if(hdrdat(1) >=r200 .and. hdrdat(1) <=r250 ) then   ! The range of satellite IDS
+              if(hdrdat(1) >=r200 .and. hdrdat(1) <=r250 ) then   ! The range of satellite IDS
                  c_prvstg='VIIRS'
                  if(hdrdat(9) == one)  then                            ! VIIRS IR winds
                     itype=260
@@ -899,48 +903,48 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                        endif
                     endif
                  enddo
-               endif
+              endif
 ! Extra block for new EUMETSAT BUFR: Start
-                 if(qifn <85.0_r_kind )  then    !  qifn, QI without forecast
-                    qm=15
-                 endif
+              if(qifn <85.0_r_kind )  then    !  qifn, QI without forecast
+                 qm=15
+              endif
            else if(trim(subset) == 'NC005067' .or. trim(subset) == 'NC005068' .or. &
                    trim(subset) == 'NC005069') then              ! read new EUM BURF
               if( hdrdat(1) <r80 .and. hdrdat(1) >= r50 ) then  ! The range of satellite IDs
-                      c_prvstg='EUMETSAT'
-                      if(hdrdat(10) >68.0_r_kind) cycle loop_readsb   !   reject data zenith angle >68.0 degree 
-                      if(hdrdat(9) == one)  then                  ! IR winds
-                         itype=253
-                         c_station_id='IR'//stationid
-                         c_sprvstg='IR'
-                      else if(hdrdat(9) == two) then              ! visible winds
-                         itype=243
-                         c_station_id='VI'//stationid
-                         c_sprvstg='VI'
-                      else if(hdrdat(9) == three) then            ! WV cloud top, try to assimilate
-                         itype=254
-                         c_station_id='WV'//stationid
-                         c_sprvstg='WV'
-                      else if(hdrdat(9) >= four) then             ! WV deep layer,monitoring
-                         itype=254
-                         qm=9                                     !  quality mark as 9, means the observation error needed to be set
-                         c_station_id='WV'//stationid
-                         c_sprvstg='WV'
-                      endif
+                 c_prvstg='EUMETSAT'
+                 if(hdrdat(10) >68.0_r_kind) cycle loop_readsb   !   reject data zenith angle >68.0 degree 
+                 if(hdrdat(9) == one)  then                  ! IR winds
+                    itype=253
+                    c_station_id='IR'//stationid
+                    c_sprvstg='IR'
+                 else if(hdrdat(9) == two) then              ! visible winds
+                    itype=243
+                    c_station_id='VI'//stationid
+                    c_sprvstg='VI'
+                 else if(hdrdat(9) == three) then            ! WV cloud top, try to assimilate
+                    itype=254
+                    c_station_id='WV'//stationid
+                    c_sprvstg='WV'
+                 else if(hdrdat(9) >= four) then             ! WV deep layer,monitoring
+                    itype=254
+                    qm=9                                     !  quality mark as 9, means the observation error needed to be set
+                    c_station_id='WV'//stationid
+                    c_sprvstg='WV'
+                 endif
 !  get quality information THIS SECTION NEEDS TO BE TESTED!!!
-                      call ufbint(lunin,rep_array,1,1,iret, '{AMVIVR}')
-                      irep_array = int(rep_array)
-                      allocate( amvivr(2,irep_array))
-                      call ufbrep(lunin,amvivr,2,irep_array,iret, 'TCOV CVWD')
-                      pct1 = amvivr(2,1)     ! use of pct1 (a new variable in the BUFR) is introduced by Nebuda/Genkova
-                      deallocate( amvivr )
+                 call ufbint(lunin,rep_array,1,1,iret, '{AMVIVR}')
+                 irep_array = int(rep_array)
+                 allocate( amvivr(2,irep_array))
+                 call ufbrep(lunin,amvivr,2,irep_array,iret, 'TCOV CVWD')
+                 pct1 = amvivr(2,1)     ! use of pct1 (a new variable in the BUFR) is introduced by Nebuda/Genkova
+                 deallocate( amvivr )
 
-                      call ufbseq(lunin,amvqic,2,4,iret, 'AMVQIC') ! AMVQIC:: GNAPS PCCF
-                      qifn = amvqic(2,2)  ! QI w/ fcst does not exist in this BUFR
-                      ee = amvqic(2,4) ! NOTE: GOES-R's ee is in [m/s]
-                      if(qifn <85.0_r_kind )  then    !  qifn, QI without forecast
-                         qm=15
-                      endif
+                 call ufbseq(lunin,amvqic,2,4,iret, 'AMVQIC') ! AMVQIC:: GNAPS PCCF
+                 qifn = amvqic(2,2)  ! QI w/ fcst does not exist in this BUFR
+                 ee = amvqic(2,4) ! NOTE: GOES-R's ee is in [m/s]
+                 if(qifn <85.0_r_kind )  then    !  qifn, QI without forecast
+                    qm=15
+                 endif
               endif
 ! Extra block for new EUMETSAT BUFR: End
 ! Extra block for VIIRS NOAA-20: Start
@@ -1081,35 +1085,36 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                     if(itype==240 .or. itype==245 .or. itype==246 .or. itype==251) then 
                     ! types 245 and 246 have been used to determine the acceptable pct1 range, but that pct1 range is applied to all GOES-R winds
            	       if (pct1 < 0.04_r_kind) qm=15  
-		       if (pct1 > 0.50_r_kind) qm=15
-		    endif
+                       if (pct1 > 0.50_r_kind) qm=15
+                    endif
                  endif
 
 ! GOES-16 additional QC addopting ECMWF's approach(Katie Lean,14IWW)-start
-                if (EC_AMV_QC) then 
-                   if (qifn < 90_r_kind .or. qifn > r100 )   qm=15 ! stricter QI
-                   if (ppb < 150.0_r_kind) qm=15                   ! all high level
-                   if (itype==251 .and. ppb < 700.0_r_kind) qm=15  ! VIS
-                   if (itype==246 .and. ppb > 300.0_r_kind) qm=15  ! WVCA 
-                   dlon_earth=hdrdat(3)*deg2rad
-                   dlat_earth=hdrdat(2)*deg2rad
-                   call deter_sfc_type(dlat_earth,dlon_earth,t4dv,isflg,tsavg)
-                   if (isflg == 1 .and. ppb > 850.0_r_kind) qm=15  ! low over land
-                endif
+                 if (EC_AMV_QC) then 
+                    if (qifn < 90_r_kind .or. qifn > r100 )   qm=15 ! stricter QI
+                    if (ppb < 150.0_r_kind) qm=15                   ! all high level
+                    if (itype==251 .and. ppb < 700.0_r_kind) qm=15  ! VIS
+                    if (itype==246 .and. ppb > 300.0_r_kind) qm=15  ! WVCA 
+                    dlon_earth=hdrdat(3)*deg2rad
+                    dlat_earth=hdrdat(2)*deg2rad
+                    call deter_sfc_type(dlat_earth,dlon_earth,t4dv,isflg,tsavg)
+                    if (isflg == 1 .and. ppb > 850.0_r_kind) qm=15  ! low over land
+                 endif
 
-                ! winds rejected by qc dont get used
-                if (qm == 15) usage=r100
-                if (qm == 3 .or. qm ==7) woe=woe*r1_2
-                ! set strings for diagnostic output
-                if(itype==240 )  then;  c_prvstg='GOESR' ; c_sprvstg='IRSW'  ; endif
-                if(itype==245 )  then;  c_prvstg='GOESR' ; c_sprvstg='IR'  ; endif
-                if(itype==246 )  then;  c_prvstg='GOESR' ; c_sprvstg='WVCT'  ; endif
-                if(itype==247 )  then;  c_prvstg='GOESR' ; c_sprvstg='WVCS'  ; endif
-                if(itype==251 )  then;  c_prvstg='GOESR' ; c_sprvstg='VIS'  ; endif
+                 ! winds rejected by qc dont get used
+                 if (qm == 15) usage=r100
+                 if (qm == 3 .or. qm ==7) woe=woe*r1_2
+                 ! set strings for diagnostic output
+                 if(itype==240 )  then;  c_prvstg='GOESR' ; c_sprvstg='IRSW'  ; endif
+                 if(itype==245 )  then;  c_prvstg='GOESR' ; c_sprvstg='IR'  ; endif
+                 if(itype==246 )  then;  c_prvstg='GOESR' ; c_sprvstg='WVCT'  ; endif
+                 if(itype==247 )  then;  c_prvstg='GOESR' ; c_sprvstg='WVCS'  ; endif
+                 if(itype==251 )  then;  c_prvstg='GOESR' ; c_sprvstg='VIS'  ; endif
               endif
 ! Extra block for GOES-R winds: End
            endif  ! assign types and get quality info : end
 
+           ! assign types and get quality info : end
 
            if ( qify == zero) qify=r110
            if ( qifn == zero) qifn=r110
@@ -1158,7 +1163,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                  endif
               endif
            endif
-       
+
 !!    convert from wind direction and speed to u,v component
            uob=-obsdat(4)*sin(obsdat(3)*deg2rad)
            vob=-obsdat(4)*cos(obsdat(3)*deg2rad)
@@ -1198,7 +1203,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                        endif
                     enddo
                     if (ncount ==1) then
-                       write(6,*) 'READ_SATWND,WARNING cannot find subtyep in the error table,&
+                       write(6,*) 'READ_SATWND,WARNING cannot find subtype in the error table,&
                                    itype,iobsub=',itypey,icsubtype(nc)
                        write(6,*) 'read error table at colomn subtype as 0,error table column=',ierr
                     endif
@@ -1268,9 +1273,9 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
                  ree=0.2_r_kind
               endif
               if( ppb >= 800.0_r_kind .and. ree >0.55_r_kind) then
-                  qm=15
+                 qm=15
               else if (ree >0.8_r_kind) then
-                  qm=15
+                 qm=15
               endif
            endif
 
@@ -1300,10 +1305,11 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
 !           if(itype==252) then;  c_prvstg='JMA'      ;  c_sprvstg='IR'       ; endif
 !           if(itype==253) then;  c_prvstg='EUMETSAT' ;  c_sprvstg='IR'       ; endif
 !           if(itype==254) then;  c_prvstg='EUMETSAT' ;  c_sprvstg='WV'       ; endif
+!           if(itype==255) then;  c_prvstg='LEOGEO'   ;  c_sprvstg='IR'       ; endif
 !           if(itype==257) then;  c_prvstg='MODIS'    ;  c_sprvstg='IR'       ; endif
 !           if(itype==258) then;  c_prvstg='MODIS'    ;  c_sprvstg='WVCTOP'   ; endif
 !           if(itype==259) then;  c_prvstg='MODIS'    ;  c_sprvstg='WVDLAYER' ; endif
-!
+!           if(itype==260) then;  c_prvstg='VIIRS'    ;  c_sprvstg='IR'       ; endif
 !           c_station_id='SATWND'
 
 ! Get information from surface file necessary for conventional data here
@@ -1453,12 +1459,14 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
            cdata_all(22,iout)=r_prvstg(1,1)       ! provider name
            cdata_all(23,iout)=r_sprvstg(1,1)      ! subprovider name
            cdata_all(25,iout)=var_jb              ! non linear qc parameter
-
+           cdata_all(26,iout)=one                 ! hilbert curve weight 
+           cdata_all(28,iout)=hdrdat(9)           ! SWCM,spectral type=1-5
+           cdata_all(29,iout)=hdrdat(10)          ! SAZA
+           cdata_all(30,iout)=hdrdat(12)          ! SCCF,spec wavenumber
            if(perturb_obs)then
-              cdata_all(26,iout)=ran01dom()*perturb_fact ! u perturbation
-              cdata_all(27,iout)=ran01dom()*perturb_fact ! v perturbation
+              cdata_all(31,iout)=ran01dom()*perturb_fact ! u perturbation
+              cdata_all(32,iout)=ran01dom()*perturb_fact ! v perturbation
            endif
-
         enddo  loop_readsb
  !   End of bufr read loop
      enddo loop_msg
@@ -1470,7 +1478,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
         call del3grids
      endif
      if (.not.use_all_tm) then
-       deallocate(presl_thin)
+        deallocate(presl_thin)
         call del3grids_tm
      endif
 

--- a/GEOSaana_GridComp/GSI_GridComp/read_satwnd.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/read_satwnd.f90
@@ -69,6 +69,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
 !                       - Read WMO pre-approved new BUFR Goes-16 AMVs (Goes-R)
 !   2018-06-13  Genkova - Goes-16 AMVs use ECMWF QC till new HAM late 2018
 !                         and OE/2 
+!   2021-06-21  Todling - Allow code to bypass hack to half-GOES-R errors
 ! 
 !   
 !
@@ -98,6 +99,7 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
        tll2xy,txy2ll,rotate_wind_ll2xy,rotate_wind_xy2ll,&
        rlats,rlons,twodvar_regional,wrf_nmm_regional
   use qcmod, only: errormod,njqc
+  use qcmod, only: half_goesr_err
   use convthin, only: make3grids,map3grids,map3grids_m,del3grids,use_all
   use convthin_time, only: make3grids_tm,map3grids_tm,map3grids_m_tm,del3grids_tm,use_all_tm
   use constants, only: deg2rad,zero,rad2deg,one_tenth,&
@@ -1275,10 +1277,12 @@ subroutine read_satwnd(nread,ndata,nodata,infile,obstype,lunout,gstime,twind,sis
 ! Reduce OE for the GOES-R winds by half following Sharon Nebuda's work
 ! GOES-R wind are identified/recognised here by subset, but it could be done by itype or SAID
 ! After completing the evaluation of GOES-R winds, REVISE this section!!!
+          if (half_goesr_err) then
             if(trim(subset) == 'NC005030' .or. trim(subset) == 'NC005031' .or. trim(subset) == 'NC005032' .or. &  
                trim(subset) == 'NC005034' .or. trim(subset) == 'NC005039' ) then  
                obserr=obserr/two
             endif
+          endif
 
 !         Set usage variable
            usage = 0 

--- a/GEOSaana_GridComp/GSI_GridComp/setupdw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupdw.f90
@@ -820,6 +820,10 @@ subroutine setupdw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )
+        if (save_jacobian) then
+          call nc_diag_header("jac_nnz", nnz)
+          call nc_diag_header("jac_nind", nind)
+        endif
      endif
   end subroutine init_netcdf_diag_
   subroutine contents_binary_diag_(odiag)
@@ -954,6 +958,9 @@ subroutine setupdw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            if (save_jacobian) then
               call fullarray(dhx_dx, dhx_dx_array)
               call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+             call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+             call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+             call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
            endif
    
   end subroutine contents_netcdf_diag_

--- a/GEOSaana_GridComp/GSI_GridComp/setuplwcp.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setuplwcp.f90
@@ -766,6 +766,10 @@ subroutine setuplwcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diag
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )
+        if (save_jacobian) then
+          call nc_diag_header("jac_nnz", nnz)
+          call nc_diag_header("jac_nind", nind)
+        endif
      endif
 
   end subroutine init_netcdf_diag_
@@ -888,6 +892,9 @@ subroutine setuplwcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diag
     if (save_jacobian) then
        call fullarray(dhx_dx, dhx_dx_array)
        call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+       call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+       call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+       call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val, r_single))
     endif
 
   end subroutine contents_netcdf_diag_

--- a/GEOSaana_GridComp/GSI_GridComp/setupps.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupps.f90
@@ -125,10 +125,11 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   use gridmod, only: nsig,get_ij,twodvar_regional
   use constants, only: zero,one_tenth,one,half,pi,g_over_rd, &
              huge_r_kind,tiny_r_kind,two,cg_term,huge_single, &
-             r1000,wgtlim,tiny_single,r10,three
+             r100,r1000,wgtlim,tiny_single,r10,three
   use jfunc, only: jiter,last,jiterstart,miter
   use qcmod, only: dfact,dfact1,npres_print,njqc,vqc
   use guess_grids, only: hrdifsig,ges_lnprsl,nfldsig,ntguessig
+  use guess_grids, only: geop_hgtl, ges_prsi, ges_tsen
   use convinfo, only: nconvtype,cermin,cermax,cgross,cvar_b,cvar_pg,ictype,icsubtype
 
   use m_dtime, only: dtime_setup, dtime_check
@@ -167,21 +168,25 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   real(r_kind) rdelz,rdp,halfpi,obserror,obserrlm,drdp,residual,ratio
   real(r_kind) errinv_input,errinv_adjst,errinv_final
   real(r_kind) err_input,err_adjst,err_final,tfact
-  real(r_kind) zsges,pgesorig,rwgt
+  real(r_kind) zsges,pgesorig,rwgt, factw, sfcr, landfrac
   real(r_kind) r0_005,r0_2,r2_5,tmin,tmax,half_tlapse
   real(r_kind) ratio_errors,error,dhgt,ddiff,dtemp
   real(r_kind) val2,ress,ressw2,val,valqc
   real(r_kind) cg_ps,wgross,wnotgross,wgt,arg,exp_arg,term,rat_err2,qcgross
   real(r_kind),dimension(nobs):: dup
   real(r_kind),dimension(nsig):: prsltmp
+  real(r_kind),dimension(nsig):: zges, prsltmp2, tvgestmp, tsentmp, qtmp, utmp, vtmp
+  real(r_kind) :: tgges,roges
+  real(r_kind),dimension(nsig+1):: prsitmp
   real(r_kind),dimension(nele,nobs):: data
   real(r_single),allocatable,dimension(:,:)::rdiagbuf
 
-  integer(i_kind) ier,ilon,ilat,ipres,ihgt,itemp,id,itime,ikx,iqc,iptrb,ijb
+  integer(i_kind) ier,ilon,ilat,ipres,ihgt,itemp,id,itime,ikx,iqc,iptrb,ijb,isli
   integer(i_kind) ier2,iuse,ilate,ilone,istnelv,idomsfc,izz,iprvd,isprvd
   integer(i_kind) ikxx,nn,ibin,ioff,ioff0
   integer(i_kind) i,nchar,nreal,ii,jj,k,l,mm1
   integer(i_kind) itype,isubtype 
+  integer(i_kind) msges
 
   logical,dimension(nobs):: luse,muse
   integer(i_kind),dimension(nobs):: ioid ! initial (pre-distribution) obs ID
@@ -206,10 +211,14 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   real(r_kind),allocatable,dimension(:,:,:  ) :: ges_ps
   real(r_kind),allocatable,dimension(:,:,:  ) :: ges_z
   real(r_kind),allocatable,dimension(:,:,:,:) :: ges_tv
+  real(r_kind),allocatable,dimension(:,:,:,:) :: ges_q
+  real(r_kind),allocatable,dimension(:,:,:,:) :: ges_u, ges_v
 
   type(sparr2) :: dhx_dx
   real(r_single), dimension(nsdim) :: dhx_dx_array
   integer(i_kind) :: ps_ind, nnz, nind
+
+  integer(i_kind) ::idft
 
   type(obsLList),pointer,dimension(:):: pshead
   pshead => obsLL(:)
@@ -242,7 +251,8 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   iprvd=18    ! index of observation provider
   isprvd=19   ! index of observation subprovider
   ijb=20      ! index of non linear qc parameter
-  iptrb=21    ! index of ps perturbation
+  idft=21     ! index of sonde profile launch time
+  iptrb=22    ! index of ps perturbation
 
 ! Declare local constants
   halfpi = half*pi
@@ -315,6 +325,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
 
   call dtime_setup()
   do i = 1,nobs
+     isli = -1
      dtime=data(itime,i)
      call dtime_check(dtime, in_curbin, in_anybin)
      if(.not.in_anybin) cycle
@@ -381,6 +392,45 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
         mype,nfldsig)
      call tintrp2a1(ges_lnprsl,prsltmp,dlat,dlon,dtime,hrdifsig,&
         nsig,mype,nfldsig)
+
+!   interpolate geopotential height to location
+    call tintrp2a1(geop_hgtl, zges, dlat, dlon, dtime, hrdifsig, nsig, mype, nfldsig)
+    prsltmp2 = exp(prsltmp) ! pressure on model layers
+    ! pressure on interfaces
+    call tintrp2a1(ges_prsi,prsitmp,dlat,dlon,dtime,hrdifsig,nsig+1,mype,nfldsig)
+    ! virtual temperature profile
+    call tintrp2a1(ges_tv,tvgestmp,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+    ! sensible temperature profile
+    call tintrp2a1(ges_tsen,tsentmp,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+    ! specific humidity
+    call tintrp2a1(ges_q,qtmp,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+    ! winds
+    call tintrp2a1(ges_u,utmp,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+    call tintrp2a1(ges_v,vtmp,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+    ! landmask
+    msges = 0
+    if(itype == 180 .or. itype == 182 .or. itype == 183 .or. itype == 199) then    !sea
+      msges=0
+    elseif(itype == 181 .or. itype == 187 .or. itype == 188) then  !land
+      msges=1
+    endif
+    
+    isli = data(idomsfc,i) ! dominate surface type
+
+     ! pre-set a surface roughness no lower than 0.1 cm
+     ! pre-set wind_reduction_factor to 1.0
+     ! pre-set land_area_fraction to 0.0 for certain ocean/sea data, otherwise 1.0
+     !  this will not be correct for satwind or aircraft data, but mostly correct otherwise
+     sfcr = 0.1
+     factw=one
+     if (itype.eq.180 .or. itype.eq.182 .or. itype.eq.183 .or. itype.eq.184 .or.       &
+             itype.eq.189 .or. itype.eq.190 .or. itype.eq.191 .or. itype.eq.194 .or.   &
+             itype.eq.199 .or. isli.eq.0) then
+        landfrac = 0.0
+     else
+        landfrac = 1.0
+     endif
+
 
 ! Convert pressure to grid coordinates
 
@@ -743,6 +793,61 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
          write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
          call stop2(999)
      endif
+!    get q ...
+     varname='q'
+     call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank3,istatus)
+     if (istatus==0) then
+         if(allocated(ges_q))then
+            write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
+            call stop2(999)
+         endif
+         allocate(ges_q(size(rank3,1),size(rank3,2),size(rank3,3),nfldsig))
+         ges_q(:,:,:,1)=rank3
+         do ifld=2,nfldsig
+            call gsi_bundlegetpointer(gsi_metguess_bundle(ifld),trim(varname),rank3,istatus)
+            ges_q(:,:,:,ifld)=rank3
+         enddo
+     else
+         write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
+         call stop2(999)
+     endif
+
+!    get u ...
+     varname='u'
+     call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank3,istatus)
+     if (istatus==0) then
+         if(allocated(ges_u))then
+            write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
+            call stop2(999)
+         endif
+         allocate(ges_u(size(rank3,1),size(rank3,2),size(rank3,3),nfldsig))
+         ges_u(:,:,:,1)=rank3
+         do ifld=2,nfldsig
+            call gsi_bundlegetpointer(gsi_metguess_bundle(ifld),trim(varname),rank3,istatus)
+            ges_u(:,:,:,ifld)=rank3
+         enddo
+     else
+         write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
+         call stop2(999)
+     endif
+!    get v ...
+     varname='v'
+     call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank3,istatus)
+     if (istatus==0) then
+         if(allocated(ges_v))then
+            write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
+            call stop2(999)
+         endif
+         allocate(ges_v(size(rank3,1),size(rank3,2),size(rank3,3),nfldsig))
+         ges_v(:,:,:,1)=rank3
+         do ifld=2,nfldsig
+            call gsi_bundlegetpointer(gsi_metguess_bundle(ifld),trim(varname),rank3,istatus)
+            ges_v(:,:,:,ifld)=rank3
+         enddo
+     else
+         write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
+         call stop2(999)
+     endif
   else
      write(6,*) trim(myname), ': inconsistent vector sizes (nfldsig,size(metguess_bundle) ',&
                  nfldsig,size(gsi_metguess_bundle)
@@ -780,6 +885,10 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )
+        if (save_jacobian) then
+          call nc_diag_header("jac_nnz", nnz)
+          call nc_diag_header("jac_nind", nind)
+        endif
      endif
 
   end subroutine init_netcdf_diag_
@@ -871,6 +980,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            call nc_diag_metadata("Pressure",                sngl(data(ipres,i)*r10))
            call nc_diag_metadata("Height",                  sngl(dhgt)             )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
+           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))     )
            call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
            call nc_diag_metadata("Prep_Use_Flag",           sngl(data(iuse,i))     )
            call nc_diag_metadata("Nonlinear_QC_Var_Jb",     sngl(var_jb)           )
@@ -881,13 +991,13 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
               call nc_diag_metadata("Analysis_Use_Flag",    sngl(-one)             )              
            endif
 
-           call nc_diag_metadata("Errinv_Input",            sngl(errinv_input)     )
-           call nc_diag_metadata("Errinv_Adjust",           sngl(errinv_adjst)     )
-           call nc_diag_metadata("Errinv_Final",            sngl(errinv_final)     )
+           call nc_diag_metadata("Errinv_Input",            sngl(errinv_input/r100)     )
+           call nc_diag_metadata("Errinv_Adjust",           sngl(errinv_adjst/r100)     )
+           call nc_diag_metadata("Errinv_Final",            sngl(errinv_final/r100)     )
 
-           call nc_diag_metadata("Observation",                   sngl(pob)        )
-           call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   sngl(pob-pges)   )
-           call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(pob-pgesorig))
+           call nc_diag_metadata("Observation",                   sngl(pob*r100)        )
+           call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   sngl((pob-pges)*r100)   )
+           call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl((pob-pgesorig)*r100))
  
           if (lobsdiagsave) then
 
@@ -917,7 +1027,29 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            if (save_jacobian) then
               call fullarray(dhx_dx, dhx_dx_array)
               call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+             call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+             call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+             call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
            endif
+           ! geovals for JEDI UFO
+           call nc_diag_metadata("surface_geopotential_height", sngl(zsges))
+           call nc_diag_metadata("surface_pressure", sngl(pgesorig*r100))
+           !call nc_diag_metadata("surface_height", sngl())
+           !call nc_diag_metadata("2m_temperature", sngl(tgges))
+           !call nc_diag_metadata("2m_specific_humidity", sngl())
+           call nc_diag_data2d("geopotential_height", sngl(zsges+zges))
+           call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp2*r1000))
+           call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
+           call nc_diag_data2d("virtual_temperature", sngl(tvgestmp))
+           call nc_diag_data2d("air_temperature", sngl(tsentmp))
+           call nc_diag_data2d("specific_humidity", sngl(qtmp))
+           call nc_diag_data2d("northward_wind", sngl(utmp))
+           call nc_diag_data2d("eastward_wind", sngl(vtmp))
+           call nc_diag_metadata("surface_temperature", sngl(tges))
+           call nc_diag_metadata("surface_roughness", sngl(sfcr/r100))
+           call nc_diag_metadata("landmask", sngl(landfrac))
+           call nc_diag_metadata("Wind_Reduction_Factor_at_10m", sngl(factw))
+
 
   end subroutine contents_netcdf_diag_
 
@@ -925,6 +1057,9 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
     if(allocated(ges_tv)) deallocate(ges_tv)
     if(allocated(ges_z )) deallocate(ges_z )
     if(allocated(ges_ps)) deallocate(ges_ps)
+    if(allocated(ges_q)) deallocate(ges_q)
+    if(allocated(ges_u)) deallocate(ges_u)
+    if(allocated(ges_v)) deallocate(ges_v)
   end subroutine final_vars_
 
 end subroutine setupps

--- a/GEOSaana_GridComp/GSI_GridComp/setuppw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setuppw.f90
@@ -105,7 +105,7 @@ subroutine setuppw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   use m_obsLList, only: obsLList
   use obsmod, only: luse_obsdiag
   use gsi_4dvar, only: nobs_bins,mn_obsbin
-  use constants, only: zero,one,tpwcon,r1000,r10, &
+  use constants, only: zero,one,tpwcon,r1000,r10,r100,&
        tiny_r_kind,three,half,two,cg_term,huge_single,&
        wgtlim, rd
   use jfunc, only: jiter,last,miter,jiterstart
@@ -121,8 +121,8 @@ subroutine setuppw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   implicit none
 
 ! Declare passed variables
-  type(obsLList ),target,dimension(:),intent(in):: obsLL
-  type(obs_diags),target,dimension(:),intent(in):: odiagLL
+  type(obsLList ),target,dimension(:),intent(inout):: obsLL
+  type(obs_diags),target,dimension(:),intent(inout):: odiagLL
 
   logical                                          ,intent(in   ) :: conv_diagsave
   integer(i_kind)                                  ,intent(in   ) :: lunin,mype,nele,nobs
@@ -264,7 +264,7 @@ subroutine setuppw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
      endif
      allocate(cdiagbuf(nobs),rdiagbuf(nreal,nobs))
      ii=0
-     if(netcdf_diag) call init_netcdf_diag_
+     if(netcdf_diag.and.nobs>0) call init_netcdf_diag_
   end if
 
 
@@ -515,7 +515,7 @@ subroutine setuppw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
 
 ! Write information to diagnostic file
   if(conv_diagsave)then
-     if(netcdf_diag) call nc_diag_write
+     if(netcdf_diag .and. nobs>0) call nc_diag_write
      if(binary_diag .and. ii>0)then
         write(7)' pw',nchar,nreal,ii,mype,ioff0
         write(7)cdiagbuf(1:ii),rdiagbuf(:,1:ii)
@@ -723,7 +723,7 @@ subroutine setuppw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            call nc_diag_metadata("Latitude",                      sngl(data(ilate,i))     )
            call nc_diag_metadata("Longitude",                     sngl(data(ilone,i))     )
            call nc_diag_metadata("Station_Elevation",             sngl(data(istnelv,i))   )
-           call nc_diag_metadata("Pressure",                      sngl(prest)             )
+           call nc_diag_metadata("Pressure",                      sngl(prest*r100)        )
            call nc_diag_metadata("Height",                        sngl(data(iobshgt,i))   )
            call nc_diag_metadata("Time",                          sngl(dtime-time_offset) )
            call nc_diag_metadata("Prep_QC_Mark",                  sngl(data(iqc,i))       )

--- a/GEOSaana_GridComp/GSI_GridComp/setupq.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupq.f90
@@ -142,6 +142,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   use gsi_4dvar, only: nobs_bins,mn_obsbin,min_offset
   use oneobmod, only: oneobtest,maginnov,magoberr
   use guess_grids, only: ges_lnprsl,hrdifsig,nfldsig,ges_tsen,ges_prsl,pbl_height
+  use guess_grids, only: geop_hgtl, ges_prsi
   use gridmod, only: lat2,lon2,nsig,get_ijk,twodvar_regional
   use constants, only: zero,one,r1000,r10,r100
   use constants, only: huge_single,wgtlim,three
@@ -197,7 +198,10 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) ratio_errors,dlat,dlon,dtime,dpres,rmaxerr,error
   real(r_kind) rsig,dprpx,rlow,rhgh,presq,tfact,ramp
   real(r_kind) psges,sfcchk,ddiff,errorx
-  real(r_kind) cg_q,wgross,wnotgross,wgt,arg,exp_arg,term,rat_err2,qcgross
+  real(r_kind) cg_q,wgross,wnotgross,arg,exp_arg,term
+  real(r_kind) zsges, factw, sfcr, landfrac
+  real(r_kind) sfctges
+  real(r_kind) cg_t,cvar,wgt,rat_err2,qcgross
   real(r_kind) grsmlt,ratio,val2,obserror
   real(r_kind) obserrlm,residual,ressw2,scale,ress,huge_error,var_jb
   real(r_kind) val,valqc,rwgt,prest
@@ -207,14 +211,16 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind),dimension(nobs):: dup
   real(r_kind),dimension(lat2,lon2,nsig,nfldsig):: qg
   real(r_kind),dimension(lat2,lon2,nfldsig):: qg2m
-  real(r_kind),dimension(nsig):: prsltmp
+  real(r_kind),dimension(nsig):: prsltmp, tvgestmp, tsentmp
+  real(r_kind),dimension(nsig):: prsltmp2, qtmp,zges, utmp, vtmp
+  real(r_kind),dimension(nsig+1):: prsitmp
   real(r_kind),dimension(34):: ptablq
   real(r_single),allocatable,dimension(:,:)::rdiagbuf
   real(r_single),allocatable,dimension(:,:)::rdiagbufp
 
 
   integer(i_kind) i,nchar,nreal,ii,l,jj,mm1,itemp,iip
-  integer(i_kind) jsig,itype,k,nn,ikxx,iptrb,ibin,ioff,ioff0,icat,ijb
+  integer(i_kind) jsig,itype,k,nn,ikxx,iptrb,ibin,ioff,ioff0,icat,ijb,isli
   integer(i_kind) ier,ilon,ilat,ipres,iqob,id,itime,ikx,iqmax,iqc
   integer(i_kind) ier2,iuse,ilate,ilone,istnelv,iobshgt,izz,iprvd,isprvd
   integer(i_kind) idomsfc,iderivative
@@ -245,6 +251,8 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) :: thispbl_height,ratio_PBL_height,prestsfc,diffsfc
   real(r_kind) :: hr_offset
 
+  integer(i_kind) :: idft
+
   equivalence(rstation_id,station_id)
   equivalence(r_prvstg,c_prvstg)
   equivalence(r_sprvstg,c_sprvstg)
@@ -252,6 +260,9 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind),allocatable,dimension(:,:,:  ) :: ges_ps
   real(r_kind),allocatable,dimension(:,:,:,:) :: ges_q
   real(r_kind),allocatable,dimension(:,:,:  ) :: ges_q2m
+  real(r_kind),allocatable,dimension(:,:,:  ) :: ges_z
+  real(r_kind),allocatable,dimension(:,:,:,:) :: ges_tv
+  real(r_kind),allocatable,dimension(:,:,:,:) :: ges_u, ges_v
 
   logical:: l_pbl_pseudo_itype
   integer(i_kind):: ich0
@@ -294,7 +305,8 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   isprvd=21   ! index of observation subprovider
   icat =22    ! index of data level category
   ijb  =23    ! index of non linear qc parameter
-  iptrb=24    ! index of q perturbation
+  idft=24     ! index of sonde profile launch time
+  iptrb=25    ! index of q perturbation
 
   var_jb=zero
   do i=1,nobs
@@ -380,6 +392,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 ! Prepare specific humidity data
   call dtime_setup()
   do i=1,nobs
+     isli = -1
      dtime=data(itime,i)
      call dtime_check(dtime, in_curbin, in_anybin)
      if(.not.in_anybin) cycle
@@ -451,6 +464,43 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
           mype,nfldsig)
      call tintrp2a1(ges_lnprsl,prsltmp,dlat,dlon,dtime,hrdifsig,&
           nsig,mype,nfldsig)
+
+!   interpolate geovals to obs locations
+    ! surface geopotential height 
+    call tintrp2a11(ges_z,zsges,dlat,dlon,dtime,hrdifsig, mype,nfldsig)
+    ! geopotential height 
+    call tintrp2a1(geop_hgtl, zges, dlat, dlon, dtime, hrdifsig, nsig, mype, nfldsig)
+    prsltmp2 = exp(prsltmp) ! pressure on model layers
+    ! pressure on interfaces
+    call tintrp2a1(ges_prsi,prsitmp,dlat,dlon,dtime,hrdifsig,nsig+1,mype,nfldsig)
+    ! virtual temperature profile
+    call tintrp2a1(ges_tv,tvgestmp,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+    ! sensible temperature profile
+    call tintrp2a1(ges_tsen,tsentmp,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+    ! specific humidity
+    call tintrp2a1(ges_q,qtmp,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+    ! winds
+    call tintrp2a1(ges_u,utmp,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+    call tintrp2a1(ges_v,vtmp,dlat,dlon,dtime,hrdifsig,nsig,mype,nfldsig)
+    ! surface temperature
+    call tintrp31(ges_tv,sfctges,dlat,dlon,log(psges),dtime, &
+         hrdifsig,mype,nfldsig)
+
+    isli = data(idomsfc,i) ! dominate surface type
+
+     ! pre-set a surface roughness no lower than 0.1 cm
+     ! pre-set wind_reduction_factor to 1.0
+     ! pre-set land_area_fraction to 0.0 for certain ocean/sea data, otherwise 1.0
+     !  this will not be correct for satwind or aircraft data, but mostly correct otherwise
+     sfcr = 0.1
+     factw=one
+     if (itype.eq.180 .or. itype.eq.182 .or. itype.eq.183 .or. itype.eq.184 .or.       &
+             itype.eq.189 .or. itype.eq.190 .or. itype.eq.191 .or. itype.eq.194 .or.   &
+             itype.eq.199 .or. isli.eq.0) then
+        landfrac = 0.0
+     else
+        landfrac = 1.0
+     endif
 
      presq=r10*exp(dpres)
      itype=ictype(ikx)
@@ -987,6 +1037,78 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
          write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
          call stop2(999)
      endif
+!    get z ...
+     varname='z'
+     call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank2,istatus)
+     if (istatus==0) then
+         if(allocated(ges_z))then
+            write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
+            call stop2(999)
+         endif
+         allocate(ges_z(size(rank2,1),size(rank2,2),nfldsig))
+         ges_z(:,:,1)=rank2
+         do ifld=2,nfldsig
+            call gsi_bundlegetpointer(gsi_metguess_bundle(ifld),trim(varname),rank2,istatus)
+            ges_z(:,:,ifld)=rank2
+         enddo
+     else
+         write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
+         call stop2(999)
+     endif
+!    get tv ...
+     varname='tv'
+     call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank3,istatus)
+     if (istatus==0) then
+         if(allocated(ges_tv))then
+            write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
+            call stop2(999)
+         endif
+         allocate(ges_tv(size(rank3,1),size(rank3,2),size(rank3,3),nfldsig))
+         ges_tv(:,:,:,1)=rank3
+         do ifld=2,nfldsig
+            call gsi_bundlegetpointer(gsi_metguess_bundle(ifld),trim(varname),rank3,istatus)
+            ges_tv(:,:,:,ifld)=rank3
+         enddo
+     else
+         write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
+         call stop2(999)
+     endif
+!    get u ...
+     varname='u'
+     call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank3,istatus)
+     if (istatus==0) then
+         if(allocated(ges_u))then
+            write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
+            call stop2(999)
+         endif
+         allocate(ges_u(size(rank3,1),size(rank3,2),size(rank3,3),nfldsig))
+         ges_u(:,:,:,1)=rank3
+         do ifld=2,nfldsig
+            call gsi_bundlegetpointer(gsi_metguess_bundle(ifld),trim(varname),rank3,istatus)
+            ges_u(:,:,:,ifld)=rank3
+         enddo
+     else
+         write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
+         call stop2(999)
+     endif
+!    get v ...
+     varname='v'
+     call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank3,istatus)
+     if (istatus==0) then
+         if(allocated(ges_v))then
+            write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
+            call stop2(999)
+         endif
+         allocate(ges_v(size(rank3,1),size(rank3,2),size(rank3,3),nfldsig))
+         ges_v(:,:,:,1)=rank3
+         do ifld=2,nfldsig
+            call gsi_bundlegetpointer(gsi_metguess_bundle(ifld),trim(varname),rank3,istatus)
+            ges_v(:,:,:,ifld)=rank3
+         enddo
+     else
+         write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
+         call stop2(999)
+     endif
   else
      write(6,*) trim(myname), ': inconsistent vector sizes (nfldsig,size(metguess_bundle) ',&
                  nfldsig,size(gsi_metguess_bundle)
@@ -1024,6 +1146,10 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )
+        if (save_jacobian) then
+          call nc_diag_header("jac_nnz", nnz)
+          call nc_diag_header("jac_nind", nind)
+        endif
      endif
   end subroutine init_netcdf_diag_
   subroutine contents_binary_diag_(odiag)
@@ -1161,6 +1287,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Pressure",                sngl(presq)            )
            call nc_diag_metadata("Height",                  sngl(data(iobshgt,i))  )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
+           call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))     )
            call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
            call nc_diag_metadata("Prep_Use_Flag",           sngl(data(iuse,i))     )
            call nc_diag_metadata("Nonlinear_QC_Var_Jb",     sngl(var_jb)           )
@@ -1204,7 +1331,25 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            if (save_jacobian) then
               call fullarray(dhx_dx, dhx_dx_array)
               call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+             call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+             call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+             call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
            endif
+           ! geovals for JEDI UFO
+           call nc_diag_metadata("surface_geopotential_height", sngl(zsges))
+           call nc_diag_metadata("surface_pressure", sngl(psges*r1000))
+           call nc_diag_metadata("surface_temperature", sngl(sfctges))
+           call nc_diag_data2d("geopotential_height", sngl(zsges+zges))
+           call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp2*r1000))
+           call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
+           call nc_diag_data2d("virtual_temperature", sngl(tvgestmp))
+           call nc_diag_data2d("air_temperature", sngl(tsentmp))
+           call nc_diag_data2d("specific_humidity", sngl(qtmp))
+           call nc_diag_data2d("northward_wind", sngl(utmp))
+           call nc_diag_data2d("eastward_wind", sngl(vtmp))
+           call nc_diag_metadata("surface_roughness", sngl(sfcr/r100))
+           call nc_diag_metadata("landmask", sngl(landfrac))
+           call nc_diag_metadata("Wind_Reduction_Factor_at_10m", sngl(factw))
 
   end subroutine contents_netcdf_diag_
 
@@ -1243,6 +1388,9 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            if (save_jacobian) then
               call fullarray(dhx_dx, dhx_dx_array)
               call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+             call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+             call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+             call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
            endif
   end subroutine contents_netcdf_diagp_
 
@@ -1250,6 +1398,10 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     if(allocated(ges_q2m)) deallocate(ges_q2m)
     if(allocated(ges_q )) deallocate(ges_q )
     if(allocated(ges_ps)) deallocate(ges_ps)
+    if(allocated(ges_z )) deallocate(ges_z )
+    if(allocated(ges_tv)) deallocate(ges_tv)
+    if(allocated(ges_u)) deallocate(ges_u)
+    if(allocated(ges_v)) deallocate(ges_v)
   end subroutine final_vars_
 
 end subroutine setupq

--- a/GEOSaana_GridComp/GSI_GridComp/setuprad.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setuprad.f90
@@ -289,11 +289,12 @@ contains
       finish_sst_retrieval,spline_cub
   use m_dtime, only: dtime_setup, dtime_check
   use crtm_interface, only: init_crtm,call_crtm,destroy_crtm,sensorindex,surface, &
-      itime,ilon,ilat,ilzen_ang,ilazi_ang,iscan_ang,iscan_pos,iszen_ang,isazi_ang, &
+      atmosphere,itime,ilon,ilat,ilzen_ang,ilazi_ang,iscan_ang,iscan_pos,iszen_ang,isazi_ang, &
       ifrac_sea,ifrac_lnd,ifrac_ice,ifrac_sno,itsavg, &
       izz,idomsfc,isfcr,iff10,ilone,ilate, &
-      isst_hires,isst_navy,idata_type,iclr_sky,itref,idtw,idtc,itz_tr
-  use crtm_interface, only: ilzen_ang2,iscan_ang2,iszen_ang2,isazi_ang2
+      isst_hires,isst_navy,idata_type,iclr_sky,itref,idtw,idtc,itz_tr,&
+      n_clouds_fwd_wk,n_actual_aerosols_wk,n_absorbers
+  use crtm_interface, only: ilzen_ang2,iscan_ang2,iszen_ang2,isazi_ang2, ilazi_ang2
   use clw_mod, only: calc_clw, ret_amsua, gmi_37pol_diff,mhs_si
   use qcmod, only: qc_ssmi,qc_seviri,qc_abi,qc_ssu,qc_avhrr,qc_goesimg,qc_msu,qc_irsnd,qc_amsua,qc_mhs,qc_atms
   use qcmod, only: igood_qc,ifail_gross_qc,ifail_interchan_qc,ifail_crtm_qc,ifail_satinfo_qc,qc_noirjaco3,ifail_cloud_qc
@@ -304,7 +305,7 @@ contains
   use radinfo, only: iland_det, isnow_det, iwater_det, imix_det, iice_det, &
                       iomg_det, itopo_det, isst_det,iwndspeed_det
   use qcmod, only: setup_tzr_qc,ifail_scanedge_qc,ifail_outside_range
-  use state_vectors, only: svars3d, levels, svars2d, ns3d, nsdim
+  use state_vectors, only: svars3d, levels, svars2d, ns3d
   use oneobmod, only: lsingleradob,obchan,oblat,oblon,oneob_type
   use correlated_obsmod, only: corr_adjust_jacobian, idnames
   use radiance_mod, only: rad_obs_type,radiance_obstype_search,radiance_ex_obserr,radiance_ex_biascor
@@ -314,8 +315,8 @@ contains
   implicit none
 
 ! Declare passed variables
-  type(obsLList ),target,dimension(:),intent(in):: obsLL
-  type(obs_diags),target,dimension(:),intent(in):: odiagLL
+  type(obsLList ),target,dimension(:),intent(inout):: obsLL
+  type(obs_diags),target,dimension(:),intent(inout):: odiagLL
   logical                           ,intent(in   ) :: rad_diagsave
   character(10)                     ,intent(in   ) :: obstype
   character(20)                     ,intent(in   ) :: isis
@@ -366,11 +367,10 @@ contains
   real(r_kind) factch6    
   real(r_kind) stability,tcwv,hwp_ratio         
   real(r_kind) si_obs,si_fg,si_mean                     
-  
+
   logical cao_flag                       
   logical hirs2,msu,goessndr,hirs3,hirs4,hirs,amsua,amsub,airs,hsb,goes_img,ahi,mhs,abi
   type(sparr2) :: dhx_dx
-  real(r_single), dimension(nsdim) :: dhx_dx_array
   logical avhrr,avhrr_navy,lextra,ssu,iasi,cris,seviri,atms
   logical ssmi,ssmis,amsre,amsre_low,amsre_mid,amsre_hig,amsr2,gmi,saphir
   logical ssmis_las,ssmis_uas,ssmis_env,ssmis_img
@@ -414,6 +414,7 @@ contains
   real(r_kind) :: tnoise_save
   real(r_kind),dimension(:), allocatable :: rsqrtinv
   real(r_kind),dimension(:), allocatable :: rinvdiag
+  real(r_kind) :: ice_temperature_0
 
 !for GMI (dual scan angles)
   real(r_kind),dimension(nchanl):: emissivity2,ts2, emissivity_k2,tsim2
@@ -833,19 +834,19 @@ contains
 
         iinstr=-1
         if(allocated(idnames)) then
-          if(sea)then
+        if(sea) then
              covtype = trim(isis)//':sea'
              iinstr=getindex(idnames,trim(covtype))
-          else if(land)then
+        else if(land) then
              covtype = trim(isis)//':land'
              iinstr=getindex(idnames,trim(covtype))
-          else if(ice)then
+        else if(ice) then
              covtype = trim(isis)//':ice'
              iinstr=getindex(idnames,trim(covtype))
-          else if(snow)then
+        else if(snow) then
              covtype = trim(isis)//':snow'
              iinstr=getindex(idnames,trim(covtype))
-          else if(mixed)then
+        else if(mixed) then
              covtype = trim(isis)//':mixed'
              iinstr=getindex(idnames,trim(covtype))
           endif
@@ -900,12 +901,13 @@ contains
         tsim_clr=zero
         tcc=zero
         if (radmod%lcloud_fwd) then
-          call call_crtm(obstype,dtime,data_s(:,n),nchanl,nreal,ich, &
+           call call_crtm(obstype,dtime,data_s(:,n),nchanl,nreal,ich, &
              tvp,qvp,clw_guess,ciw_guess,rain_guess,snow_guess,prsltmp,prsitmp, &
-             trop5,tzbgr,dtsavg,sfc_speed, &
-             tsim,emissivity,ptau5,ts,emissivity_k, &
+                trop5,tzbgr,dtsavg,sfc_speed, &
+                tsim,emissivity,ptau5,ts,emissivity_k, &
                 temp,wmix,jacobian,error_status,tsim_clr=tsim_clr,tcc=tcc, & 
-                tcwv=tcwv,hwp_ratio=hwp_ratio,stability=stability, tpwc_guess=tpwc_guess)         
+                tcwv=tcwv,hwp_ratio=hwp_ratio,stability=stability, tpwc_guess=tpwc_guess,&
+                ice_temperature_0=ice_temperature_0)         
           if(gmi) then
              gmi_low_angles(1:3)=data_s(ilzen_ang:iscan_ang,n)
              gmi_low_angles(4:5)=data_s(iszen_ang:isazi_ang,n)
@@ -933,11 +935,11 @@ contains
              cosza2 = cos(data_s(ilzen_ang2,n))
           endif
         else
-          call call_crtm(obstype,dtime,data_s(:,n),nchanl,nreal,ich, &
+           call call_crtm(obstype,dtime,data_s(:,n),nchanl,nreal,ich, &
              tvp,qvp,clw_guess,ciw_guess,rain_guess,snow_guess,prsltmp,prsitmp, &
-             trop5,tzbgr,dtsavg,sfc_speed, &
-             tsim,emissivity,ptau5,ts,emissivity_k, &
-             temp,wmix,jacobian,error_status)
+                trop5,tzbgr,dtsavg,sfc_speed, &
+                tsim,emissivity,ptau5,ts,emissivity_k, &
+                temp,wmix,jacobian,error_status,ice_temperature_0=ice_temperature_0)
           if(gmi) then
              gmi_low_angles(1:3)=data_s(ilzen_ang:iscan_ang,n)
              gmi_low_angles(4:5)=data_s(iszen_ang:isazi_ang,n)
@@ -962,7 +964,7 @@ contains
              data_s(ilzen_ang:iscan_ang, n) = gmi_low_angles(1:3)
              data_s(iszen_ang:isazi_ang, n) = gmi_low_angles(4:5)
              cosza2 = cos(data_s(ilzen_ang2,n))
-          endif
+        endif 
         endif
 
 ! If the CRTM returns an error flag, do not assimilate any channels for this ob 
@@ -1029,7 +1031,7 @@ contains
         tpwc_obs=zero
         kraintype=0
         cldeff_obs=zero 
-        cldeff_fg=zero  
+        cldeff_fg=zero 
         if(microwave .and. sea) then 
            if(radmod%lcloud_fwd .and. (amsua .or. atms)) then
               call ret_amsua(tb_obs,nchanl,tsavg5,zasat,clw_obs,ierrret,scat)
@@ -1114,7 +1116,7 @@ contains
            else
               pred(3,i) = clw_obs*cosza*cosza
            end if
-           if(radmod%lcloud_fwd .and. sea) pred(3,i ) = zero
+           if(radmod%lcloud_fwd .and. sea) pred(3,i ) = zero 
  
 
 
@@ -1218,7 +1220,7 @@ contains
 
 !       End of loop over channels
         end do
-
+ 
 !       Compute retrieved microwave cloud liquid water and 
 !       assign cld_rbc_idx for bias correction in allsky conditions
         cld_rbc_idx=one
@@ -1297,7 +1299,7 @@ contains
               enddo
            endif
 
-        end if !radmod%lcloud_fwd .and. radmod%ex_biascor
+        end if ! radmod%lcloud_fwd .and. radmod%ex_biascor
         
         do i=1,nchanl
            error0(i) = tnoise(i)
@@ -1630,7 +1632,7 @@ contains
                  else if(radmod%rtype == 'mhs') then
                     errf(i) = min(two*errf(i),ermax_rad(m))
                  else if (radmod%rtype/='amsua' .and. radmod%rtype/='atms' .and. radmod%rtype/='gmi' .and. radmod%rtype/='mhs' .and. radmod%lcloud4crtm(i)>=0) then
-                    errf(i) = three*errf(i)    
+                    errf(i) = three*errf(i)
                  else 
                     errf(i) = min(three*errf(i),ermax_rad(m))
                  endif
@@ -2309,7 +2311,8 @@ contains
            if(.not. retrieval)then
               diagbuf(15) = surface(1)%water_temperature      ! surface temperature over water (K)
               diagbuf(16) = surface(1)%land_temperature       ! surface temperature over land (K)
-              diagbuf(17) = surface(1)%ice_temperature        ! surface temperature over ice (K)
+!             diagbuf(17) = surface(1)%ice_temperature        ! surface temperature over ice (K)
+              diagbuf(17) = ice_temperature_0                 ! surface temperature over ice (K) (input to CRTM)
               diagbuf(18) = surface(1)%snow_temperature       ! surface temperature over snow (K)
               diagbuf(19) = surface(1)%soil_temperature       ! soil temperature (K)
               if (gmi .or. saphir) then
@@ -2523,6 +2526,8 @@ contains
   real(r_single),parameter::  missing = -9.99e9_r_single
   integer(i_kind),parameter:: imissing = -999999
   real(r_kind),dimension(:),allocatable :: predbias_angord
+  character(128) :: fieldname
+  integer(i_kind) :: iabsorb, icloud
 
   if (adp_anglebc) then
     allocate(predbias_angord(angord) )
@@ -2545,30 +2550,31 @@ contains
                     call nc_diag_metadata("Sol_Zenith_Angle",   sngl(data_s(iszen_ang2,n))          ) ! solar zenith angle (degrees)
                     call nc_diag_metadata("Sol_Azimuth_Angle",  sngl(data_s(isazi_ang2,n))          ) ! solar azimuth angle (degrees)
                     call nc_diag_metadata("Scan_Angle",         sngl(data_s(iscan_ang2,n)*rad2deg)  ) ! scan angle
+                    call nc_diag_metadata("Sat_Azimuth_Angle",  sngl(data_s(ilazi_ang2,n))           ) ! satellite azimuth angle (degrees)
                  else
-                 call nc_diag_metadata("Sat_Zenith_Angle",      sngl(zasat*rad2deg)                 ) ! satellite zenith angle (degrees)
-                 call nc_diag_metadata("Sol_Zenith_Angle",      sngl(pangs)                         ) ! solar zenith angle (degrees)
-                 call nc_diag_metadata("Sol_Azimuth_Angle",     sngl(data_s(isazi_ang,n))           ) ! solar azimuth angle (degrees)
+                    call nc_diag_metadata("Sat_Zenith_Angle",      sngl(zasat*rad2deg)                 ) ! satellite zenith angle (degrees)
+                    call nc_diag_metadata("Sol_Zenith_Angle",      sngl(pangs)                         ) ! solar zenith angle (degrees)
+                    call nc_diag_metadata("Sol_Azimuth_Angle",     sngl(data_s(isazi_ang,n))           ) ! solar azimuth angle (degrees)
                     call nc_diag_metadata("Scan_Angle",         sngl(data_s(iscan_ang,n)*rad2deg)   ) ! scan angle
+                    call nc_diag_metadata("Sat_Azimuth_Angle",     sngl(data_s(ilazi_ang,n))           ) ! satellite azimuth angle (degrees)
                  endif
-                 call nc_diag_metadata("Sat_Azimuth_Angle",     sngl(data_s(ilazi_ang,n))           ) ! satellite azimuth angle (degrees)
                  call nc_diag_metadata("Sun_Glint_Angle",       sngl(sgagl)                         ) ! sun glint angle (degrees) (sgagl)
 
 
-                 call nc_diag_metadata("Water_Fraction",        sngl(surface(1)%water_coverage)     ) ! fractional coverage by water
-                 call nc_diag_metadata("Land_Fraction",         sngl(surface(1)%land_coverage)      ) ! fractional coverage by land
-                 call nc_diag_metadata("Ice_Fraction",          sngl(surface(1)%ice_coverage)       ) ! fractional coverage by ice
-                 call nc_diag_metadata("Snow_Fraction",         sngl(surface(1)%snow_coverage)      ) ! fractional coverage by snow
+                 call nc_diag_metadata("Water_Fraction",        sngl(data_s(ifrac_sea,n))             ) ! fractional coverage by water
+                 call nc_diag_metadata("Land_Fraction",         sngl(data_s(ifrac_lnd,n))             ) ! fractional coverage by land
+                 call nc_diag_metadata("Ice_Fraction",          sngl(data_s(ifrac_ice,n))             ) ! fractional coverage by ice
+                 call nc_diag_metadata("Snow_Fraction",         sngl(data_s(ifrac_sno,n))             ) ! fractional coverage by snow
 
                  if(.not. retrieval)then
                     call nc_diag_metadata("Water_Temperature",     sngl(surface(1)%water_temperature) ) ! surface temperature over water (K)
                     call nc_diag_metadata("Land_Temperature",      sngl(surface(1)%land_temperature)  ) ! surface temperature over land (K)
-                    call nc_diag_metadata("Ice_Temperature",       sngl(surface(1)%ice_temperature)   ) ! surface temperature over ice (K)
+!                   call nc_diag_metadata("Ice_Temperature",       sngl(surface(1)%ice_temperature)   ) ! surface temperature over ice (K) 
+                    call nc_diag_metadata("Ice_Temperature",       sngl(ice_temperature_0)            ) ! surface temperature over ice (K)  (input to CRTM)
                     call nc_diag_metadata("Snow_Temperature",      sngl(surface(1)%snow_temperature)  ) ! surface temperature over snow (K)
                     call nc_diag_metadata("Soil_Temperature",      sngl(surface(1)%soil_temperature)  ) ! soil temperature (K)
                     call nc_diag_metadata("Soil_Moisture",         sngl(surface(1)%soil_moisture_content) ) ! soil moisture
                     call nc_diag_metadata("Land_Type_Index",       surface(1)%land_type             ) ! surface land type
-                    call nc_diag_metadata("tsavg5",                missing                          ) ! SST first guess used for SST retrieval
                     call nc_diag_metadata("sstcu",                 missing                          ) ! NCEP SST analysis at t            
                     call nc_diag_metadata("sstph",                 missing                          ) ! Physical SST retrieval             
                     call nc_diag_metadata("sstnv",                 missing                          ) ! Navy SST retrieval               
@@ -2583,7 +2589,6 @@ contains
                     call nc_diag_metadata("Soil_Temperature",      missing                          ) ! soil temperature (K)
                     call nc_diag_metadata("Soil_Moisture",         missing                          ) ! soil moisture
                     call nc_diag_metadata("Land_Type_Index",       imissing                         ) ! surface land type
-                    call nc_diag_metadata("tsavg5",                sngl(tsavg5)                     ) ! SST first guess used for SST retrieval
                     call nc_diag_metadata("sstcu",                 sngl(sstcu)                      ) ! NCEP SST analysis at t            
                     call nc_diag_metadata("sstph",                 sngl(sstph)                      ) ! Physical SST retrieval             
                     call nc_diag_metadata("sstnv",                 sngl(sstnv)                      ) ! Navy SST retrieval               
@@ -2591,12 +2596,15 @@ contains
                     call nc_diag_metadata("dqa",                   sngl(dqa)                        ) ! d(qa) corresponding to sstph
                     call nc_diag_metadata("dtp_avh",               sngl(dtp_avh)                    ) ! data type             
                  endif
+                 call nc_diag_metadata("tsavg5",                sngl(tsavg5)                     ) ! SST first guess used for SST retrieval
 
                  call nc_diag_metadata("Vegetation_Fraction",   sngl(surface(1)%vegetation_fraction) )
                  call nc_diag_metadata("Snow_Depth",            sngl(surface(1)%snow_depth)         )
+                 call nc_diag_metadata("tpwc_amsua",            sngl(tpwc_obs)                      ) ! cope w/ NCEP outdated changes
+                 call nc_diag_metadata("tpwc",                  sngl(tpwc_obs)                      ) ! this should be the general name
                  call nc_diag_metadata("tpwc_guess",            sngl(tpwc_guess)                    ) ! model column q (kg/m^2)
-!                call nc_diag_metadata("tpwc",                  sngl(tpwc_obs)                      )
                  call nc_diag_metadata("clw_guess_retrieval",   sngl(clw_guess_retrieval)           )
+                 call nc_diag_metadata("clwp_amsua",            sngl(clw_obs)                       ) !_RT: ease IODA conversion NCEP needs to clean up
                  call nc_diag_metadata("scat_amsua",            sngl(scat)                          )
 
                  call nc_diag_metadata("Sfc_Wind_Speed",        sngl(surface(1)%wind_speed)         )
@@ -2605,8 +2613,8 @@ contains
                  call nc_diag_metadata("CLW",                   sngl(clw_obs)                       )
                  call nc_diag_metadata("TPWC",                  sngl(tpwc_obs)                      )
                  call nc_diag_metadata("clw_obs",               sngl(clw_obs)                       )
-                 call nc_diag_metadata("clwp_amsua",            sngl(clw_obs)                       ) !_RT: ease IODA conversion NCEP needs to clean up
                  call nc_diag_metadata("clw_guess",             sngl(clw_guess)                     )
+                 call nc_diag_metadata("tropopause_pressure",   sngl(trop5*1000)                    )  ! Pa  (kPa*1000)
 
                  if (nstinfo==0) then
                     data_s(itref,n)  = missing
@@ -2624,20 +2632,17 @@ contains
                  call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   sngl(tbc0(ich_diag(i)  ))  )     ! observed - simulated Tb with bias corrrection (K)
                  call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(tbcnob(ich_diag(i)))  )     ! observed - simulated Tb with no bias correction (K)
                  call nc_diag_metadata("Forecast_unadjusted_clear",     sngl(tsim_clr(ich_diag(i))))     ! simulated Tb under clear-sky condition
-
-                 errinv = sqrt(varinv0(ich_diag(i)))
-                 call nc_diag_metadata("Inverse_Observation_Error",     sngl(errinv)               )
-                 call nc_diag_metadata("Input_Observation_Error",       sngl(error0(ich_diag(i)))  )   ! observed brightness temperature (K)
-                 if (save_jacobian .and. allocated(idnames)) then
-                    call nc_diag_metadata("Observation_scaled", sngl(tb_obs(ich_diag(i)))  )     ! observed brightness temperature (K) scaled by R^{-1/2}
-                    call nc_diag_metadata("Obs_Minus_Forecast_adjusted_scaled", sngl(tbc(ich_diag(i)))  )     ! observed - simulated Tb with bias corrrection (K) scaled by R^{-1/2}
-                    errinv = sqrt(varinv(ich_diag(i)))
-                    call nc_diag_metadata("Inverse_Observation_Error_scaled", sngl(errinv)          )
-
-                    call nc_diag_metadata("Bias_Correction", sngl(tbcnob(ich_diag(i))-tbc(ich_diag(i)))) ! bias correction
-                    call nc_diag_metadata("Bias_Correction_Constant", sngl(predbias(1,ich_diag(i))))        ! constant bias correction
-                    call nc_diag_metadata("Bias_Correction_ScanAngle", sngl(predbias(npred+1,ich_diag(i)))) ! scan angle bias correction
-                 endif
+                 call nc_diag_metadata("Forecast_adjusted_clear",       sngl(tsim_clr_bc(ich_diag(i))))     ! simulated Tb under clear-sky condition
+                 call nc_diag_metadata("Forecast_unadjusted",           sngl(tb_obs(ich_diag(i))-tbcnob(ich_diag(i)))) ! simulated Tb with no bias correction
+                 call nc_diag_metadata("Forecast_adjusted",             sngl(tb_obs(ich_diag(i))-tbc(ich_diag(i)))     ) ! simulated Tb with bias correction
+           !     call nc_diag_metadata("Bias_Correction", sngl(tbc(ich_diag(i))-tbcnob(ich_diag(i)))       ) ! bias correction
+                 call nc_diag_metadata("Bias_Correction", sngl(tbcnob(ich_diag(i))-tbc(ich_diag(i)))       ) ! bias correction
+                 call nc_diag_metadata("Bias_Correction_Constant", sngl(predbias(1,ich_diag(i)))           ) ! constant bias correction
+                 call nc_diag_metadata("Bias_Correction_ScanAngle", sngl(predbias(npred+1,ich_diag(i)))    ) ! scan angle bias correction
+                 ! Write out obs error in physical space for CrIS, IASI, and AIRS. varinv0 = varinv for other radiance data (Wei Gu).
+                 errinv = sqrt(varinv0(ich_diag(i))) 
+                 call nc_diag_metadata("Inverse_Observation_Error", sngl(errinv)                           ) ! inverse of observaton error
+                 call nc_diag_metadata("Input_Observation_Error", sngl(error0(ich_diag(i)))                ) ! input observation error
 
                  if (save_jacobian) then
                     j = 1
@@ -2668,7 +2673,6 @@ contains
                        endif
                     enddo
 
-                    call fullarray(dhx_dx, dhx_dx_array)
                     call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
                     call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
                     call nc_diag_data2d("Observation_Operator_Jacobian_val",  real(dhx_dx%val,r_single))
@@ -2719,6 +2723,26 @@ contains
                     endif
                  end if
 
+                 call nc_diag_metadata("Vegetation_Type", sngl(surface(1)%vegetation_type))
+                 call nc_diag_metadata("Lai",             sngl(surface(1)%lai))
+                 call nc_diag_metadata("Soil_Type",  sngl(surface(1)%soil_type))
+
+                 call nc_diag_metadata("Sfc_Wind_Direction", sngl(surface(1)%wind_direction)    )
+                 call nc_diag_metadata("Sfc_Height",    sngl(zsges    ) )
+                 call nc_diag_data2d("air_temperature", sngl(atmosphere(1)%temperature) )  ! K 
+                 call nc_diag_data2d("air_pressure", sngl(atmosphere(1)%pressure*r100))
+                 call nc_diag_data2d("air_pressure_levels", sngl(atmosphere(1)%level_pressure*r100) )
+
+                 do iabsorb = 1, n_absorbers
+                   write (fieldname, "(A,I0.2)") "atmosphere_absorber_", atmosphere(1)%absorber_id(iabsorb)
+                   call nc_diag_data2d(trim(fieldname), sngl(atmosphere(1)%absorber(:,iabsorb)))  ! check %absorber_units
+                 enddo
+                 do icloud = 1, n_clouds_fwd_wk
+                   write (fieldname, "(A,I0.2)") "atmosphere_mass_content_of_cloud_", atmosphere(1)%Cloud(icloud)%Type
+                   call nc_diag_data2d(trim(fieldname), sngl(atmosphere(1)%Cloud(icloud)%Water_Content))
+                   write (fieldname, "(A,I0.2)") "effective_radius_of_cloud_particle_", atmosphere(1)%Cloud(icloud)%Type
+                   call nc_diag_data2d(trim(fieldname), sngl(atmosphere(1)%Cloud(icloud)%Effective_Radius))
+                 enddo
               enddo
 !  if (adp_anglebc) then
     if(allocated(predbias_angord)) deallocate(predbias_angord)

--- a/GEOSaana_GridComp/GSI_GridComp/setuprw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setuprw.f90
@@ -1069,6 +1069,10 @@ subroutine setuprw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )
+        if (save_jacobian) then
+          call nc_diag_header("jac_nnz", nnz)
+          call nc_diag_header("jac_nind", nind)
+        endif
      endif
   end subroutine init_netcdf_diag_
   subroutine contents_binary_diag_(odiag)
@@ -1191,6 +1195,9 @@ subroutine setuprw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            if (save_jacobian) then
               call fullarray(dhx_dx, dhx_dx_array)
               call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+              call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+              call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+              call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
            endif
    
   end subroutine contents_netcdf_diag_

--- a/GEOSaana_GridComp/GSI_GridComp/setupspd.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupspd.f90
@@ -829,6 +829,10 @@ subroutine setupspd(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )
+        if (save_jacobian) then
+          call nc_diag_header("jac_nnz", nnz)
+          call nc_diag_header("jac_nind", nind)
+        endif
      endif
   end subroutine init_netcdf_diag_
   subroutine contents_binary_diag_(odiag)
@@ -967,6 +971,9 @@ subroutine setupspd(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
            if (save_jacobian) then
               call fullarray(dhx_dx, dhx_dx_array)
               call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+             call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+             call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+             call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
            endif
 
 

--- a/GEOSaana_GridComp/GSI_GridComp/setupsst.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupsst.f90
@@ -606,6 +606,13 @@ contains
            call nc_diag_metadata("Observation",                   sngl(data(isst,i)) )
            call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   sngl(ddiff)      )
            call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(data(isst,i)-sstges) )
+
+           if (nst_gsi>0) then
+              call nc_diag_metadata("FoundationTempBG",        sngl(data(itref,i)) )
+              call nc_diag_metadata("DiurnalWarming_at_zob",   sngl(data(idtw,i)) )
+              call nc_diag_metadata("SkinLayerCooling_at_zob", sngl(data(idtw,i)) )
+              call nc_diag_metadata("Sensitivity_Tzob_Tr",     sngl(data(itz_tr,i)) )
+           endif
  
            if (lobsdiagsave) then
               do jj=1,miter

--- a/GEOSaana_GridComp/GSI_GridComp/setupswcp.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupswcp.f90
@@ -811,6 +811,10 @@ subroutine setupswcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diag
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )
+        if (save_jacobian) then
+          call nc_diag_header("jac_nnz", nnz)
+          call nc_diag_header("jac_nind", nind)
+        endif
      endif
 
   end subroutine init_netcdf_diag_
@@ -933,6 +937,9 @@ subroutine setupswcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diag
     if (save_jacobian) then
        call fullarray(dhx_dx, dhx_dx_array)
        call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+       call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+       call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+       call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
     endif
 
   end subroutine contents_netcdf_diag_

--- a/GEOSaana_GridComp/GSI_GridComp/setupt.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupt.f90
@@ -56,12 +56,12 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   use jfunc, only: jiter,last,jiterstart,miter
 
   use guess_grids, only: nfldsig, hrdifsig,ges_lnprsl,&
-       geop_hgtl,ges_tsen,pbl_height
+       geop_hgtl,ges_prsi,ges_tsen,pbl_height
   use state_vectors, only: svars3d, levels, nsdim
 
   use constants, only: zero, one, four,t0c,rd_over_cp,three,rd_over_cp_mass,ten
   use constants, only: tiny_r_kind,half,two,cg_term
-  use constants, only: huge_single,r1000,wgtlim,r10,fv
+  use constants, only: huge_single,r1000,wgtlim,r10,fv,r100
   use constants, only: one_quad
   use convinfo, only: nconvtype,cermin,cermax,cgross,cvar_b,cvar_pg,ictype,icsubtype
   use converr_t, only: ptabl_t 
@@ -238,7 +238,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) rsig,drpx,rsigp
   real(r_kind) psges,sfcchk,pres_diff,rlow,rhgh,ramp
   real(r_kind) pof_idx,poaf,effective
-  real(r_kind) tges
+  real(r_kind) tges,zsges, factw, sfcr, landfrac
   real(r_kind) obserror,ratio,val2,obserrlm,ratiosfc
   real(r_kind) residual,ressw2,scale,ress,ratio_errors,tob,ddiff
   real(r_kind) val,valqc,dlon,dlat,dtime,dpres,error,prest,rwgt,var_jb
@@ -253,18 +253,21 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind),dimension(npredt):: predcoef
   real(r_kind) tgges,roges
   real(r_kind),dimension(nsig):: tvtmp,qtmp,utmp,vtmp,hsges
+  real(r_kind),dimension(nsig):: tvgestmp,tsentmp,qgestmp,zges,ugestmp,vgestmp
   real(r_kind) u10ges,v10ges,t2ges,q2ges,psges2,f10ges
+  real(r_kind) :: sfctges 
   real(r_kind),dimension(34) :: ptablt
   real(r_single),allocatable,dimension(:,:)::rdiagbuf
   real(r_single),allocatable,dimension(:,:)::rdiagbufp
 
 
-  real(r_kind),dimension(nsig):: prsltmp2
+  real(r_kind),dimension(nsig):: prsltmp2,prsltmp3
+  real(r_kind),dimension(nsig+1):: prsitmp
 
   integer(i_kind) i,j,nchar,nreal,k,ii,iip,jj,l,nn,ibin,idia,idia0,ix,ijb
   integer(i_kind) mm1,jsig,iqt
   integer(i_kind) itype,msges
-  integer(i_kind) ier,ilon,ilat,ipres,itob,id,itime,ikx,iqc,iptrb,icat,ipof,ivvlc,idx
+  integer(i_kind) ier,ilon,ilat,ipres,itob,id,itime,ikx,iqc,iptrb,icat,ipof,ivvlc,idx,isli
   integer(i_kind) ier2,iuse,ilate,ilone,ikxx,istnelv,iobshgt,izz,iprvd,isprvd
   integer(i_kind) regime
   integer(i_kind) idomsfc,iskint,iff10,isfcr
@@ -299,6 +302,8 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind) :: thisPBL_height,ratio_PBL_height,prestsfc,diffsfc,dthetav
   real(r_kind) :: tges2m,qges2m,tges2m_water,qges2m_water
   real(r_kind) :: hr_offset
+
+  integer(i_kind) :: idft
 
   equivalence(rstation_id,station_id)
   equivalence(r_prvstg,c_prvstg)
@@ -363,13 +368,15 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   isprvd=23   ! index of observation subprovider
   icat=24     ! index of data level category
   ijb=25      ! index of non linear qc parameter
+  idft=26     ! index of sonde profile launch time
+
   if (aircraft_t_bc_pof .or. aircraft_t_bc .or. aircraft_t_bc_ext) then
-     ipof=26     ! index of data pof
-     ivvlc=27    ! index of data vertical velocity
-     idx=28      ! index of tail number
-     iptrb=29    ! index of t perturbation
+     ipof=27     ! index of data pof
+     ivvlc=28    ! index of data vertical velocity
+     idx=29      ! index of tail number
+     iptrb=30    ! index of t perturbation
   else
-     iptrb=26    ! index of t perturbation
+     iptrb=27    ! index of t perturbation
   end if
 
   do i=1,nobs
@@ -446,6 +453,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   rsigp=rsig+one
   call dtime_setup()
   do i=1,nobs
+     isli = -1
      dtime=data(itime,i)
      call dtime_check(dtime, in_curbin, in_anybin)
      if(.not.in_anybin) cycle
@@ -598,6 +606,53 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
           mype,nfldsig)
      call tintrp2a1(ges_lnprsl,prsltmp,dlat,dlon,dtime,hrdifsig,&
           nsig,mype,nfldsig)
+
+     prsltmp3 = exp(prsltmp) ! pressure on model layers
+
+! Surface geopotential height at obs location/times
+     call tintrp2a11(ges_z,zsges,dlat,dlon,dtime,hrdifsig,&
+          mype,nfldsig)
+! Geopotential height at obs location/times
+     call tintrp2a1(geop_hgtl,zges,dlat,dlon,dtime,hrdifsig,&
+          nsig,mype,nfldsig)
+! Pressure on the interfaces at obs location/times
+     call tintrp2a1(ges_prsi,prsitmp,dlat,dlon,dtime,hrdifsig,&
+          nsig+1,mype,nfldsig)
+! Virtual temperature profile at obs location/times
+     call tintrp2a1(ges_tv,tvgestmp,dlat,dlon,dtime,hrdifsig,&
+          nsig,mype,nfldsig)
+! sensible temperature profile
+     call tintrp2a1(ges_tsen,tsentmp,dlat,dlon,dtime,hrdifsig,&
+          nsig,mype,nfldsig)
+! temperature at surface
+     call tintrp31(ges_tv,sfctges,dlat,dlon,log(psges),dtime, &
+          hrdifsig,mype,nfldsig)
+! specific humidity profile at obs location/times
+     call tintrp2a1(ges_q,qgestmp,dlat,dlon,dtime,hrdifsig,&
+          nsig,mype,nfldsig)
+! wind u-component at obs location/times
+     call tintrp2a1(ges_u,ugestmp,dlat,dlon,dtime,hrdifsig,&
+          nsig,mype,nfldsig)
+! wind v-component at obs location/times
+     call tintrp2a1(ges_v,vgestmp,dlat,dlon,dtime,hrdifsig,&
+          nsig,mype,nfldsig)
+
+    isli = data(idomsfc,i) ! dominate surface type
+
+     ! pre-set a surface roughness no lower than 0.1 cm
+     ! pre-set wind_reduction_factor to 1.0
+     ! pre-set land_area_fraction to 0.0 for certain ocean/sea data, otherwise 1.0
+     !  this will not be correct for satwind or aircraft data, but mostly correct otherwise
+     sfcr = 0.1
+     factw=one
+     if (itype.eq.180 .or. itype.eq.182 .or. itype.eq.183 .or. itype.eq.184 .or.       &
+             itype.eq.189 .or. itype.eq.190 .or. itype.eq.191 .or. itype.eq.194 .or.   &
+             itype.eq.199 .or. isli.eq.0) then
+        landfrac = 0.0
+     else
+        landfrac = 1.0
+     endif
+
 
      drpx=zero
      if(sfctype .and. .not.twodvar_regional) then
@@ -1247,7 +1302,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
      varname='ps'
      call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank2,istatus)
      if (istatus==0) then
-         if(allocated(ges_z))then
+         if(allocated(ges_ps))then
             write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
             call stop2(999)
          endif
@@ -1297,6 +1352,24 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
          write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
          call stop2(999)
      endif
+!    get z ...
+     varname='z'
+     call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank2,istatus)
+     if (istatus==0) then
+         if(allocated(ges_z))then
+            write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
+            call stop2(999)
+         endif
+         allocate(ges_z(size(rank2,1),size(rank2,2),nfldsig))
+         ges_z(:,:,1)=rank2
+         do ifld=2,nfldsig
+            call gsi_bundlegetpointer(gsi_metguess_bundle(ifld),trim(varname),rank2,istatus)
+            ges_z(:,:,ifld)=rank2
+         enddo
+     else
+         write(6,*) trim(myname),': ', trim(varname), ' not found in met bundle, ier= ',istatus
+         call stop2(999)
+     endif
 !    get tv ...
      varname='tv'
      call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank3,istatus)
@@ -1338,7 +1411,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         varname='th2m'
         call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank2,istatus)
         if (istatus==0) then
-            if(allocated(ges_z))then
+            if(allocated(ges_th2))then
                write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
                call stop2(999)
             endif
@@ -1356,7 +1429,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         varname='q2m'
         call gsi_bundlegetpointer(gsi_metguess_bundle(1),trim(varname),rank2,istatus)
         if (istatus==0) then
-            if(allocated(ges_z))then
+            if(allocated(ges_q2))then
                write(6,*) trim(myname), ': ', trim(varname), ' already incorrectly alloc '
                call stop2(999)
             endif
@@ -1412,6 +1485,10 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         call nc_diag_header("Number_of_Predictors", npredt         ) ! number of updating bias correction predictors
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )
+        if (save_jacobian) then
+          call nc_diag_header("jac_nnz", nnz)
+          call nc_diag_header("jac_nind", nind)
+        endif
      endif
 
   end subroutine init_netcdf_diag_
@@ -1555,13 +1632,14 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     call nc_diag_metadata("Station_ID",              station_id             )
     call nc_diag_metadata("Observation_Class",       obsclass               )
     call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
-!    call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+    call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
     call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
     call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
     call nc_diag_metadata("Station_Elevation",       sngl(data(istnelv,i))  )
     call nc_diag_metadata("Pressure",                sngl(prest)            )
     call nc_diag_metadata("Height",                  sngl(data(iobshgt,i))  )
     call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
+    call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))     )
     call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )
     call nc_diag_metadata("Setup_QC_Mark",           sngl(data(iqt,i))      )
     call nc_diag_metadata("Prep_Use_Flag",           sngl(data(iuse,i))     )
@@ -1580,6 +1658,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(tob-tges)   )
     if (aircraft_t_bc_pof .or. aircraft_t_bc .or. aircraft_t_bc_ext) then
        call nc_diag_metadata("Data_Pof",             sngl(data(ipof,i))     )
+       call nc_diag_metadata("Data_Vertical_Velocity", sngl(data(ivvlc,i))  )
        if (npredt .gt. one) then
           call nc_diag_data2d("Bias_Correction_Terms", sngl(predbias) )
        else if (npredt .eq. one) then
@@ -1587,6 +1666,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        endif
     else
        call nc_diag_metadata("Data_Pof",                 missing                )
+       call nc_diag_metadata("Data_Vertical_Velocity",   missing                )
        if (npredt .gt. one) then
           do j=1,npredt
              predbias(j) = missing
@@ -1624,7 +1704,25 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     if (save_jacobian) then
        call fullarray(dhx_dx, dhx_dx_array)
        call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+       call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+       call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+       call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
     endif
+    ! geovals for JEDI UFO
+    call nc_diag_metadata("surface_geopotential_height",sngl(zsges))
+    call nc_diag_metadata("surface_pressure",sngl(psges*r1000))
+    call nc_diag_data2d("geopotential_height", sngl(zges+zsges))
+    call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp3*r1000))
+    call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
+    call nc_diag_data2d("virtual_temperature", sngl(tvgestmp))
+    call nc_diag_data2d("air_temperature", sngl(tsentmp))
+    call nc_diag_data2d("specific_humidity", sngl(qgestmp))
+    call nc_diag_data2d("eastward_wind", sngl(ugestmp))
+    call nc_diag_data2d("northward_wind", sngl(vgestmp))
+    call nc_diag_metadata("surface_temperature", sngl(sfctges))
+    call nc_diag_metadata("surface_roughness", sngl(sfcr/r100))
+    call nc_diag_metadata("landmask", sngl(landfrac))
+    call nc_diag_metadata("Wind_Reduction_Factor_at_10m", sngl(factw))
 
   end subroutine contents_netcdf_diag_
 
@@ -1636,7 +1734,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     call nc_diag_metadata("Station_ID",              station_id             )
     call nc_diag_metadata("Observation_Class",       obsclass               )
     call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
-!    call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+    call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
     call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
     call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
     call nc_diag_metadata("Station_Elevation",       sngl(data(istnelv,i))  )
@@ -1663,16 +1761,22 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     if (save_jacobian) then
        call fullarray(dhx_dx, dhx_dx_array)
        call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+       call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+       call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+       call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
     endif
 
   end subroutine contents_netcdf_diagp_
 
   subroutine final_vars_
     if(allocated(ges_q )) deallocate(ges_q )
+    if(allocated(ges_q )) deallocate(ges_z )
     if(allocated(ges_tv)) deallocate(ges_tv)
     if(allocated(ges_v )) deallocate(ges_v )
     if(allocated(ges_u )) deallocate(ges_u )
     if(allocated(ges_ps)) deallocate(ges_ps)
+    if(allocated(ges_q2)) deallocate(ges_q2)
+    if(allocated(ges_th2)) deallocate(ges_th2)
   end subroutine final_vars_
 
 end subroutine setupt

--- a/GEOSaana_GridComp/GSI_GridComp/setuptcp.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setuptcp.f90
@@ -70,7 +70,7 @@ subroutine setuptcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
           ntguessig
   use gridmod, only: get_ij,nsig
   use constants, only: zero,half,one,tiny_r_kind,two,cg_term, &
-          wgtlim,g_over_rd,huge_r_kind,pi,huge_single,tiny_single,r10
+          wgtlim,g_over_rd,huge_r_kind,pi,huge_single,tiny_single,r10,r1000
   use convinfo, only: nconvtype,cermin,cermax,cgross,cvar_b,cvar_pg,ictype,&
           icsubtype
   use jfunc, only: jiter,last,jiterstart,miter
@@ -79,8 +79,8 @@ subroutine setuptcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
   use gsi_metguess_mod, only : gsi_metguess_get,gsi_metguess_bundle
   implicit none
 
-  type(obsLList ),target,dimension(:),intent(in):: obsLL
-  type(obs_diags),target,dimension(:),intent(in):: odiagLL
+  type(obsLList ),target,dimension(:),intent(inout):: obsLL
+  type(obs_diags),target,dimension(:),intent(inout):: odiagLL
 
   integer(i_kind)                                  ,intent(in   ) :: lunin,mype,nele,nobs
   integer(i_kind)                                  ,intent(in   ) :: is ! ndat index
@@ -116,7 +116,7 @@ subroutine setuptcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
   real(r_kind) pob,pges,pgesorig,half_tlapse,ddiff,halfpi,r0_005,rdelz,psges2
 
   real(r_kind),dimension(nele,nobs):: data
-  real(r_kind),dimension(nsig)::prsltmp
+  real(r_kind),dimension(nsig)::prsltmp,tvges
 
   type(sparr2) :: dhx_dx
   real(r_single), dimension(nsdim) :: dhx_dx_array
@@ -252,6 +252,8 @@ subroutine setuptcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
      call tintrp2a11(ges_ps,psges,dlat,dlon,dtime,hrdifsig,&
         mype,nfldsig)
      call tintrp2a1(ges_lnprsl,prsltmp,dlat,dlon,dtime,hrdifsig,&
+        nsig,mype,nfldsig)
+     call tintrp2a1(ges_tv,tvges,dlat,dlon,dtime,hrdifsig,&
         nsig,mype,nfldsig)
 
 ! Convert pressure to grid coordinates
@@ -666,7 +668,7 @@ subroutine setuptcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
            call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
            call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
            call nc_diag_metadata("Station_Elevation",       sngl(zero)             )
-           call nc_diag_metadata("Pressure",                sngl(data(ipres,i)*r10))
+           call nc_diag_metadata("Pressure",                sngl(data(ipres,i)*r1000))
            call nc_diag_metadata("Height",                  sngl(zero)             )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
            call nc_diag_metadata("Prep_QC_Mark",            sngl(one)              )
@@ -709,6 +711,11 @@ subroutine setuptcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
             call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
             call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
           endif
+
+           call nc_diag_data2d("virtual_temperature", tvges)
+
+           call nc_diag_metadata("surface_air_pressure", psges )
+           call nc_diag_metadata("surface_geopotential_height", zsges )
 
   end subroutine contents_netcdf_diag_
 

--- a/GEOSaana_GridComp/GSI_GridComp/setuptcp.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setuptcp.f90
@@ -588,6 +588,10 @@ subroutine setuptcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
      if (.not. append_diag) then ! don't write headers on append - the module will break?
         call nc_diag_header("date_time",ianldate )
         call nc_diag_header("Number_of_state_vars", nsdim          )
+        if (save_jacobian) then
+          call nc_diag_header("jac_nnz", nnz)
+          call nc_diag_header("jac_nind", nind)
+        endif
      endif
   end subroutine init_netcdf_diag_
   subroutine contents_binary_diag_(odiag)
@@ -701,6 +705,9 @@ subroutine setuptcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
           if (save_jacobian) then
               call fullarray(dhx_dx, dhx_dx_array)
               call nc_diag_data2d("Observation_Operator_Jacobian", dhx_dx_array)
+            call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
+            call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)
+            call nc_diag_data2d("Observation_Operator_Jacobian_val", real(dhx_dx%val,r_single))
           endif
 
   end subroutine contents_netcdf_diag_


### PR DESCRIPTION
Update CRTM coefs path in "analyzer" (04/2022)
Major updates in  setuprad.f90 and crtm_interface.f90
* Updated from GEOS5.29 in order to write out various diagnostics.  (04/2022)
* Write out tropopause pressure  (05/09/2022)
* Write out obs error in physical space for CrIS, IASI, and AIRS. varinv0 = varinv for other radiance data (Wei Gu). (05/17/2022)
* Write out the original surface(1)%ice_temperature (ice_temperature_0). (05/19/2022)
   The surface(1)%ice_temperature may be altered by CRTM and creates discrepancy between UFO and GSI hofx values.
* Write out original Water_Fraction,  Land_Fraction, Ice_Fraction, and Snow_Fraction. (06/14/2022)
* Write out "Forecast_adjusted_clear" for validation. (06/14/2022)
* Updated setupw.f90 in which atmospheric pressure levels are saved along with other variable. (06/19/2022)

Added "half_goesr_err" in gsimod.F90, and qcmod.f90 which was updated in x0045,  which is not necessary for producing UFO testing files (03/2022). 