### PR TITLE
Spire config used/for x0046d

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi.rc.tmpl
@@ -19,7 +19,7 @@
    biascor=-0.10,bcoption=0,diurnalbc=1.0,
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.false.,
-   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=55.,lgpsbnd_revint=.true.,
    commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    lbicg=.true.,lcongrad=.false.,ltlint=.true.,

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fdda_1.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fdda_1.rc.tmpl
@@ -19,7 +19,7 @@
    biascor=-0.10,bcoption=0,diurnalbc=1.0,
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.true.,
-   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=55.,lgpsbnd_revint=.true.,
    commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,nmn_obsbin=@VAROBSBIN,thin4d=.true.,

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fdda_2.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fdda_2.rc.tmpl
@@ -19,7 +19,7 @@
    biascor=-0.10,bcoption=0,diurnalbc=1.0,
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.true.,
-   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=55.,lgpsbnd_revint=.true.,
    commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,nmn_obsbin=@VAROBSBIN,thin4d=.true.,

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fgat_1.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fgat_1.rc.tmpl
@@ -19,7 +19,7 @@
    biascor=-0.10,bcoption=0,diurnalbc=1.0,
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.true.,
-   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=55.,lgpsbnd_revint=.true.,
    commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,nmn_obsbin=@VAROBSBIN,

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fgat_2.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_fgat_2.rc.tmpl
@@ -19,7 +19,7 @@
    biascor=-0.10,bcoption=0,diurnalbc=1.0,
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.true.,
-   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=55.,lgpsbnd_revint=.true.,
    commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,nmn_obsbin=@VAROBSBIN,

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_sens.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_sens.rc.tmpl
@@ -20,7 +20,7 @@
    biascor=-0.10,bcoption=0,diurnalbc=1.0,
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.false.,
-   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=55.,lgpsbnd_revint=.true.,
    commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
 !  l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,

--- a/GEOSaana_GridComp/GSI_GridComp/etc/obs.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/obs.rc.tmpl
@@ -20,7 +20,7 @@
    biascor=-0.10,bcoption=0,diurnalbc=1.0,
    crtm_coeffs_path="CRTM_Coeffs/",
    print_diag_pcg=.true.,
-   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=60.,lgpsbnd_revint=.true.,
+   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=55.,lgpsbnd_revint=.true.,
    commgpstop=45.,spiregpserrinf=2.,
    use_sp_eqspace=.true.,
    l4dvar=.true.,nhr_assimilation=@VARWINDOW,nmn_obsbin=@VAROBSBIN,

--- a/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
@@ -610,6 +610,7 @@ subroutine setupbend(obsLL,odiagLL, &
      geooptics = data(isatid,i)==265 .or. data(isatid,i)==266
      planetiq  = data(isatid,i)==267 .or. data(isatid,i)==268
      spire     = data(isatid,i)==269
+     commdat   = spire.or.geooptics.or.planetiq
      if(ratio_errors(i) > tiny_r_kind)  then ! obs inside model grid
 
        if (alt <= six) then
@@ -725,11 +726,9 @@ subroutine setupbend(obsLL,odiagLL, &
 
          repe_gps=exp(repe_gps) ! one/modified error in (rad-1*1E3)
          repe_gps= r1em3*(one/abs(repe_gps)) ! modified error in rad
-         commdat=.false.
          if (spire) then
              repe_gps=spiregpserrinf*repe_gps ! Inflate error for SPIRE data
          endif
-         commdat = spire.or.geooptics.or.planetiq
          ratio_errors(i) = data(ier,i)/abs(repe_gps)
   
          error(i)=one/data(ier,i) ! one/original error
@@ -855,7 +854,7 @@ subroutine setupbend(obsLL,odiagLL, &
               else   
 !                 Statistics QC check if obs passed gross error check
                   cutoff=zero
-                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
+                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756).or.commdat) then
                      cutoff1=(-4.725_r_kind+0.045_r_kind*alt+0.005_r_kind*alt**2)*one/two
                   else
                      cutoff1=(-4.725_r_kind+0.045_r_kind*alt+0.005_r_kind*alt**2)*two/three
@@ -866,12 +865,12 @@ subroutine setupbend(obsLL,odiagLL, &
                   else
                      cutoff3=0.005_r_kind*trefges**2-2.3_r_kind*trefges+266_r_kind
                   endif
-                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
+                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756).or.commdat) then
                      cutoff3=cutoff3*one/two
                   else
                      cutoff3=cutoff3*two/three
                   end if
-                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
+                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756).or.commdat) then
                      cutoff4=(four+eight*cos(data(ilate,i)*deg2rad))*one/two
                   else
                      cutoff4=(four+eight*cos(data(ilate,i)*deg2rad))*two/three
@@ -890,7 +889,7 @@ subroutine setupbend(obsLL,odiagLL, &
                   if((alt<=six).and.(alt>four)) cutoff=cutoff34
                   if(alt<=four) cutoff=cutoff4
   
-                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756)) then
+                  if ((data(isatid,i) > 749).and.(data(isatid,i) < 756).or.commdat) then
                      cutoff=two*cutoff*r0_01
                   else
                      cutoff=three*cutoff*r0_01


### PR DESCRIPTION
This is the Spire RO configuration tested in x0046d - all passed with neutral changes to results. This provide a politically correct implementation, ie, using the data w/o gain/harm. Ideally the sigO's level for Spire can be reexamined to try and gain more from the data. x0046d used operational data stream from NCEP; x0046c used NASA (full profile version) in which impact was largely positive, but w/ a stream that can not be available in real time.

The changes here are zero-diff is Spire not used.