### PR TITLE
Correct sat_altitude value and turn off parallel reading of amsre data.

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/read_amsre_gmao.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/read_amsre_gmao.f90
@@ -197,7 +197,7 @@ integer(i_kind),dimension(npe)  ,intent(inout) :: nobs
   do_noise_reduction = .true.
   if (amsr2_method == 0) do_noise_reduction = .false.
 ! Orbit altitude  (m)
-  sat_altitude = 7.05+5_r_kind
+  sat_altitude = 7.05e+5_r_kind
 
   ilon = 3
   ilat = 4

--- a/GEOSaana_GridComp/GSI_GridComp/read_obs.F90
+++ b/GEOSaana_GridComp/GSI_GridComp/read_obs.F90
@@ -995,7 +995,7 @@ subroutine read_obs(ndata,mype)
              else if(avhrr)then
                 parallel_read(i)= .true.
              else if(amsre)then
-                parallel_read(i)= .true.
+!               parallel_read(i)= .true.  ! turn parallel read off 
              else if(obstype == 'goes_img' )then
                 parallel_read(i)= .true.
              else if(obstype == 'ahi' )then


### PR DESCRIPTION
Corrected sat_altitude value in read_amsre_gmao.f90.  Turned off parallel reading of amsre data in read_obs.F90.  AMSRE Data are not combined correctly for unknown reasons when parallel reading is conducted, which causes analysis to crash.  