### PR TITLE
UFO JEDI update brakes FSOI

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_sens.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_sens.rc.tmpl
@@ -187,8 +187,7 @@ OBS_INPUT::
    avcsambufr     avhrr       metop-b     avhrr3_metop-b        0.0     1      0        ncep_avcsam_bufr
 !  omieffbufr     omieff      aura        omieff_aura           0.0     2      0        test
    omieffnc       omieff      aura        omieff_aura           0.0     2      0        aura_omieff_nc
-   ompsnmeffnc    ompsnmeff   npp         ompsnmeff_npp         1.0     2      0        npp_ompsnmeff_nc
-!  mlstbufr       t           aura        t                     0.0     0      0        test
+   ompsnmeffnc    ompsnmeff   npp         ompsnmeff_npp         0.0     2      0        npp_ompsnmeff_nc
    gsnd1bufr      sndrd1      g15         sndrD1_g15            0.0     1      0        ncep_goesfv_bufr
    gsnd1bufr      sndrd2      g15         sndrD2_g15            0.0     1      0        ncep_goesfv_bufr
    gsnd1bufr      sndrd3      g15         sndrD3_g15            0.0     1      0        ncep_goesfv_bufr

--- a/GEOSaana_GridComp/GSI_GridComp/genstats_gps.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/genstats_gps.f90
@@ -441,7 +441,7 @@ subroutine genstats_gps(bwork,awork,toss_gps_sub,conv_diagsave,mype)
         end do
      END DO
      if(icnt > 0)then
-        nreal =22
+        nreal =30
         ioff  =nreal
         if (lobsdiagsave) nreal=nreal+4*miter+1
         if (save_jacobian) then
@@ -513,7 +513,7 @@ subroutine genstats_gps(bwork,awork,toss_gps_sub,conv_diagsave,mype)
 !       zero (effectively tossing the obs).
  
         rhgt = gps_allptr%loc
-        mreal = 22
+        mreal = 30
         if(dtype == zero) then !refractivity
           if (rhgt<=toss_gps(kprof)) then
              if(ratio_errors*data_ier > tiny_r_kind) then ! obs was good


### PR DESCRIPTION
RO changes to add extra attributes to UFO/JEDI brake (bin) diag file particularly troubled for FSOI.  This provides a fix ... the fact is that NREAL should be defined in a single place only to avoid this from happening over and over again. This is zero diff in forward mode, but not in backward mode since it fixes a bug.