### PR TITLE
Delete unneeded call to closbf

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/read_cris.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/read_cris.f90
@@ -405,7 +405,6 @@ subroutine read_cris(mype,val_cris,ithin,isfcalc,rmesh,jsatid,gstime,&
      end if
 
 !    Open BUFR file
-     call closbf(lnbufr)
      open(lnbufr,file=trim(infile2),form='unformatted',status='old',iostat=ierr)
      if(ierr /= 0) cycle ears_db_loop
 

--- a/GEOSaana_GridComp/GSI_GridComp/read_iasi.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/read_iasi.f90
@@ -414,7 +414,6 @@ subroutine read_iasi(mype,val_iasi,ithin,isfcalc,rmesh,jsatid,gstime,&
      end if
 
 !    Open BUFR file
-     call closbf(lnbufr)
      open(lnbufr,file=trim(infile2),form='unformatted',status='old',iostat=ierr)
 
      if(ierr /= 0) cycle ears_db_loop


### PR DESCRIPTION
The "closbf" call used to be needed because there was an "openbf" call earlier in the program. Between CVS v1.26.2.1 and v1.26.2.2 that "openbf" call was removed but the (now unneeded) "closbf" call was not removed.  It isn't a problem with the static allocation BUFR lib but it caused a problem when the BUFR lib was compiled with DYNAMIC allocation.   

The code may or may not be a problem with a later version of the BUFR library, I haven't tested.  However this call to closbf is clearly not needed anymore. Let's just get rid of this call.