### PR TITLE
Assign the obstypes of drifting buoys to 180 or 280.

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/convinfo.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/convinfo.f90
@@ -77,6 +77,7 @@ module convinfo
   public :: use_prepb_satwnd
   public :: index_sub
   public :: id_drifter
+  public :: subtype_drifter
   public :: id_ship
   public :: ec_amv_qc
 
@@ -91,6 +92,7 @@ module convinfo
            rmesh_conv,pmesh_conv,pmot_conv,ptime_conv
   integer(i_kind),allocatable,dimension(:):: ncmiter,ncgroup,ncnumgrp,icuse,ictype,icsubtype,&
            ithin_conv,index_sub
+  integer(i_kind) subtype_drifter
   character(len=16),allocatable,dimension(:)::ioctype
 
   logical,save :: convinfo_initialized=.false.
@@ -128,6 +130,9 @@ contains
     mype_conv = 0         ! mpi task to collect and print conv obs use information 
     use_prepb_satwnd=.false.  ! allow use of satwind stored in prepbufr file
     id_drifter=.false.        ! modify KX of drifting buoys
+    subtype_drifter=3         ! A assigned subtype for drifting buoys in some nc_diag files 
+                              ! after their obstypes are re-assigned to 180 or 280 from 199 or 299
+                              ! when id_drifter = true.
     id_ship=.false.           ! modify KX of ships
     ec_amv_qc=.true.
 

--- a/GEOSaana_GridComp/GSI_GridComp/setupps.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupps.f90
@@ -139,6 +139,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   use gsi_metguess_mod, only : gsi_metguess_get,gsi_metguess_bundle
   use sparsearr, only: sparr2, new, size, writearray, fullarray
   use rapidrefresh_cldsurf_mod, only: l_closeobs
+  use convinfo, only: id_drifter, subtype_drifter
 
   implicit none
 
@@ -973,8 +974,13 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   real(r_kind),dimension(miter) :: obsdiag_iuse
            call nc_diag_metadata("Station_ID",              station_id             )
            call nc_diag_metadata("Observation_Class",       obsclass               )
-           call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
-           call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+           if ((int(ictype(ikx)) == 199 .or. int(ictype(ikx)) == 299) .and. id_drifter ) then
+              call nc_diag_metadata("Observation_Type",        ictype(ikx)-19         )
+              call nc_diag_metadata("Observation_Subtype",     subtype_drifter        )
+           else
+              call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
+              call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+           endif
            call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
            call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
            call nc_diag_metadata("Station_Elevation",       sngl(data(istnelv,i))  )

--- a/GEOSaana_GridComp/GSI_GridComp/setupq.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupq.f90
@@ -162,6 +162,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   use gsi_metguess_mod, only : gsi_metguess_get,gsi_metguess_bundle
   use sparsearr, only: sparr2, new, size, writearray, fullarray
   use state_vectors, only: svars3d, levels, nsdim
+  use convinfo, only: id_drifter, subtype_drifter
 
   implicit none
 
@@ -1280,8 +1281,13 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
            call nc_diag_metadata("Station_ID",              station_id             )
            call nc_diag_metadata("Observation_Class",       obsclass               )
-           call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
-           call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+           if ((int(ictype(ikx)) == 199 .or. int(ictype(ikx)) == 299) .and. id_drifter ) then
+              call nc_diag_metadata("Observation_Type",        ictype(ikx)-19         )
+              call nc_diag_metadata("Observation_Subtype",     subtype_drifter        )
+           else
+              call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
+              call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+           endif
            call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
            call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
            call nc_diag_metadata("Station_Elevation",       sngl(data(istnelv,i))  )
@@ -1364,10 +1370,13 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
            call nc_diag_metadata("Station_ID",              station_id             )
            call nc_diag_metadata("Observation_Class",       obsclass               )
-           call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
-           call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
-           call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
-           call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
+           if ((int(ictype(ikx)) == 199 .or. int(ictype(ikx)) == 299) .and. id_drifter ) then
+              call nc_diag_metadata("Observation_Type",        ictype(ikx)-19         )
+              call nc_diag_metadata("Observation_Subtype",     subtype_drifter        )
+           else
+              call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
+              call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+           endif
            call nc_diag_metadata("Station_Elevation",       sngl(data(istnelv,i))  )
            call nc_diag_metadata("Pressure",                sngl(presq*r100)       )
            call nc_diag_metadata("Height",                  sngl(data(iobshgt,i))  )

--- a/GEOSaana_GridComp/GSI_GridComp/setupt.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupt.f90
@@ -83,6 +83,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   use buddycheck_mod, only: buddy_check_t
 
   use sparsearr, only: sparr2, new, size, writearray, fullarray
+  use convinfo, only: id_drifter, subtype_drifter
 
   implicit none
 
@@ -1640,8 +1641,13 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   if(.not.do_nc_diag) return
     call nc_diag_metadata("Station_ID",              station_id             )
     call nc_diag_metadata("Observation_Class",       obsclass               )
-    call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
-    call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+    if ((int(ictype(ikx)) == 199 .or. int(ictype(ikx)) == 299) .and. id_drifter ) then
+       call nc_diag_metadata("Observation_Type",        ictype(ikx)-19         )
+       call nc_diag_metadata("Observation_Subtype",     subtype_drifter        )
+    else
+       call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
+       call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+    endif
     call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
     call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
     call nc_diag_metadata("Station_Elevation",       sngl(data(istnelv,i))  )
@@ -1747,8 +1753,13 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   if(.not.do_nc_diag) return
     call nc_diag_metadata("Station_ID",              station_id             )
     call nc_diag_metadata("Observation_Class",       obsclass               )
-    call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
-    call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+    if ((int(ictype(ikx)) == 199 .or. int(ictype(ikx)) == 299) .and. id_drifter ) then
+       call nc_diag_metadata("Observation_Type",        ictype(ikx)-19         )
+       call nc_diag_metadata("Observation_Subtype",     subtype_drifter        )
+    else
+       call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
+       call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+    endif
     call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
     call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
     call nc_diag_metadata("Station_Elevation",       sngl(data(istnelv,i))  )

--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -1881,10 +1881,11 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_data2d("air_temperature", sngl(tsentmp))
               call nc_diag_data2d("specific_humidity", sngl(qges))
            endif
+           call nc_diag_metadata("Dominant_Sfc_Type", sngl(data(idomsfc,i))           )
            call nc_diag_metadata("surface_roughness", sngl(sfcr/r100))
            call nc_diag_metadata("surface_skin_temperature", sngl(skint))
            call nc_diag_metadata("landmask", sngl(landfrac))
-
+           call nc_diag_metadata("tropopause_pressure",   sngl(trop5*100)  )  ! Pa  (hPa*100)
 
   end subroutine contents_netcdf_diag_
 

--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -71,6 +71,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   use gsi_bundlemod, only : gsi_bundlegetpointer
   use gsi_metguess_mod, only : gsi_metguess_get,gsi_metguess_bundle
   use sparsearr, only: sparr2, new, size, writearray, fullarray
+  use convinfo, only: id_drifter, subtype_drifter
 
   implicit none
   
@@ -1748,8 +1749,13 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
            call nc_diag_metadata("Station_ID",              station_id             )
            call nc_diag_metadata("Observation_Class",       obsclass               )
-           call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
-           call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+           if ((int(ictype(ikx)) == 199 .or. int(ictype(ikx)) == 299) .and. id_drifter ) then
+              call nc_diag_metadata("Observation_Type",        ictype(ikx)-19         )
+              call nc_diag_metadata("Observation_Subtype",     subtype_drifter        )
+           else
+              call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
+              call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+           endif
            call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
            call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
            call nc_diag_metadata("Station_Elevation",       sngl(data(ielev,i))    )


### PR DESCRIPTION
1) In order to avoid conflicts in IODA converter, the obstypes of drifting buoys are re-assigned to 180 or 280 from 199 or 299 in GEOS NetCDF diagnostic files only. In addition, assign sub-type 3 for these data in order to separate those data from other ship data.
2) Save "Dominant_Sfc_Type" and "tropopause_pressure" in setupw.f90 