### PR TITLE
Correct geopotential_height outputs in NetCDF diag files.

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
@@ -484,8 +484,8 @@ subroutine setupbend(obsLL,odiagLL, &
 
       Tvir(1:nsig,i)      = tges(1:nsig)            ! virtual temperature
       sphm(1:nsig,i)      = qges(1:nsig)            ! specific humidity
-      hgtl(1:nsig,i)      = hges(1:nsig) + zsges    ! mid level geopotential height
-      hgti(1:nsig+1,i)    = hgesi(1:nsig+1) + zsges  ! interface level geopotential height
+      hgtl(1:nsig,i)      = hges(1:nsig)            ! mid level geopotential height
+      hgti(1:nsig+1,i)    = hgesi(1:nsig+1)         ! interface level geopotential height
       prslni(1:nsig+1,i)  = prsltmp(1:nsig+1)       ! interface level log(pressure)
       prslnl(1:nsig,i)    = prstmpl(1:nsig)         !  mid level log(pressure)
 

--- a/GEOSaana_GridComp/GSI_GridComp/setupps.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupps.f90
@@ -1047,7 +1047,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
               !call nc_diag_metadata("surface_height", sngl())
               !call nc_diag_metadata("2m_temperature", sngl(tgges))
               !call nc_diag_metadata("2m_specific_humidity", sngl())
-              call nc_diag_data2d("geopotential_height", sngl(zsges+zges))
+              call nc_diag_data2d("geopotential_height", sngl(zges))
               call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp2*r1000))
               call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
               call nc_diag_data2d("virtual_temperature", sngl(tvgestmp))

--- a/GEOSaana_GridComp/GSI_GridComp/setupq.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupq.f90
@@ -1349,7 +1349,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_metadata("surface_geopotential_height", sngl(zsges))
               call nc_diag_metadata("surface_pressure", sngl(psges*r1000))
               call nc_diag_metadata("surface_temperature", sngl(sfctges))
-              call nc_diag_data2d("geopotential_height", sngl(zsges+zges))
+              call nc_diag_data2d("geopotential_height", sngl(zges))
               call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp2*r1000))
               call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
               call nc_diag_data2d("virtual_temperature", sngl(tvgestmp))

--- a/GEOSaana_GridComp/GSI_GridComp/setupt.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupt.f90
@@ -1730,7 +1730,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        call nc_diag_metadata("surface_geopotential_height",sngl(zsges))
        call nc_diag_metadata("surface_pressure",sngl(psges*r1000))
        call nc_diag_metadata("surface_temperature", sngl(sfctges))
-       call nc_diag_data2d("geopotential_height", sngl(zges+zsges))
+       call nc_diag_data2d("geopotential_height", sngl(zges))
        call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp3*r1000))
        call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
        call nc_diag_data2d("virtual_temperature", sngl(tvgestmp))

--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -248,7 +248,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind),dimension(nele,nobs):: data
   real(r_kind),dimension(nobs):: dup
   real(r_kind),dimension(nsig+1)::prsitmp
-  real(r_kind),dimension(nsig)::prsltmp,tges,zges,qges,zges2
+  real(r_kind),dimension(nsig)::prsltmp,tges,zges,qges
   real(r_kind),dimension(nsig)::tsentmp,zges_read,uges,vges,prsltmp2
   real(r_kind) wdirob,wdirgesin,wdirdiffmax
   real(r_kind),dimension(34)::ptabluv
@@ -600,10 +600,6 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 !       at observation location.
         call tintrp2a1(geop_hgtl,zges,dlat,dlon,dtime,hrdifsig,&
              nsig,mype,nfldsig)
-
-!       Keep the original geopotential height field in zges2 because we need to
-!       write out full column.
-        zges2 = zges
 
 !       For observation reported with geometric height above sea level,
 !       convert geopotential to geometric height.
@@ -1879,7 +1875,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp2*r1000))
               call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
               call nc_diag_data2d("virtual_temperature", sngl(tges))
-              call nc_diag_data2d("geopotential_height", sngl(zges2+zsges))
+              call nc_diag_data2d("geopotential_height", sngl(zges_read))
               call nc_diag_data2d("eastward_wind", sngl(uges))
               call nc_diag_data2d("northward_wind", sngl(vges))
               call nc_diag_data2d("air_temperature", sngl(tsentmp))


### PR DESCRIPTION
Correct geopotential_height outputs by not to add surface geopotential heights upon them.
Save geopotential height for all observational types in setupw.f90.