### PR TITLE
Save geometric_height of model levels in nc_diag files for wind.

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
@@ -484,8 +484,8 @@ subroutine setupbend(obsLL,odiagLL, &
 
       Tvir(1:nsig,i)      = tges(1:nsig)            ! virtual temperature
       sphm(1:nsig,i)      = qges(1:nsig)            ! specific humidity
-      hgtl(1:nsig,i)      = hges(1:nsig)            ! mid level geopotential height
-      hgti(1:nsig+1,i)    = hgesi(1:nsig+1)         ! interface level geopotential height
+      hgtl(1:nsig,i)      = hges(1:nsig) + zsges    ! mid level geopotential height
+      hgti(1:nsig+1,i)    = hgesi(1:nsig+1) + zsges ! interface level geopotential height
       prslni(1:nsig+1,i)  = prsltmp(1:nsig+1)       ! interface level log(pressure)
       prslnl(1:nsig,i)    = prstmpl(1:nsig)         !  mid level log(pressure)
 

--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -625,8 +625,6 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
 !       Get guess surface elevation and geopotential height profile 
 !       at observation location.
-        call tintrp2a1(geop_hgtl,zges,dlat,dlon,dtime,hrdifsig,&
-             nsig,mype,nfldsig)
 
 !       For observation reported with geometric height above sea level,
 !       convert geopotential to geometric height.

--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -250,6 +250,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_kind),dimension(nobs):: dup
   real(r_kind),dimension(nsig+1)::prsitmp
   real(r_kind),dimension(nsig)::prsltmp,tges,zges,qges
+  real(r_kind),dimension(nsig)::zges_geometric
   real(r_kind),dimension(nsig)::tsentmp,zges_read,uges,vges,prsltmp2
   real(r_kind) wdirob,wdirgesin,wdirdiffmax
   real(r_kind),dimension(34)::ptabluv
@@ -559,6 +560,28 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
      call tintrp31(ges_tv,sfctges,dlat,dlon,log(psges),dtime, &
           hrdifsig,mype,nfldsig)
 
+!    Convert geopotential height at layer midpoints to geometric 
+!    height using equations (17, 20, 23) in MJ Mahoney's note 
+!    "A discussion of various measures of altitude" (2001).  
+!    Available on the web at
+!    http://mtp.jpl.nasa.gov/notes/altitude/altitude.html
+!
+!    termg  = equation 17
+!    termr  = equation 21
+!    termrg = first term in the denominator of equation 23
+!    zges  = equation 23
+
+     slat = data(ilate,i)*deg2rad
+     sin2  = sin(slat)*sin(slat)
+     termg = grav_equator * &
+          ((one+somigliana*sin2)/sqrt(one-eccentricity*eccentricity*sin2))
+     termr = semi_major_axis /(one + flattening + grav_ratio -  &
+          two*flattening*sin2)
+     termrg = (termg/grav)*termr
+     do k=1,nsig
+        zges_geometric(k) = (termr*zges_read(k)) / (termrg-zges_read(k))  ! eq (23)
+     end do
+ 
      itype=ictype(ikx)
 
 !    Type 221=pibal winds contain a mixture of wind observations reported
@@ -609,28 +632,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 !       convert geopotential to geometric height.
 
         if ((itype>=223 .and. itype<=228) .or. sfc_data) then
-!          Convert geopotential height at layer midpoints to geometric 
-!          height using equations (17, 20, 23) in MJ Mahoney's note 
-!          "A discussion of various measures of altitude" (2001).  
-!          Available on the web at
-!          http://mtp.jpl.nasa.gov/notes/altitude/altitude.html
-!
-!          termg  = equation 17
-!          termr  = equation 21
-!          termrg = first term in the denominator of equation 23
-!          zges  = equation 23
-
-           slat = data(ilate,i)*deg2rad
-           sin2  = sin(slat)*sin(slat)
-           termg = grav_equator * &
-                ((one+somigliana*sin2)/sqrt(one-eccentricity*eccentricity*sin2))
-           termr = semi_major_axis /(one + flattening + grav_ratio -  &
-                two*flattening*sin2)
-           termrg = (termg/grav)*termr
-           do k=1,nsig
-              zges(k) = (termr*zges(k)) / (termrg-zges(k))  ! eq (23)
-           end do
- 
+           zges = zges_geometric
         endif
 
 !       Given observation height, (1) adjust 10 meter wind factor if
@@ -1883,6 +1885,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
               call nc_diag_data2d("virtual_temperature", sngl(tges))
               call nc_diag_data2d("geopotential_height", sngl(zges_read))
+              call nc_diag_data2d("geometric_height", sngl(zges_geometric))
               call nc_diag_data2d("eastward_wind", sngl(uges))
               call nc_diag_data2d("northward_wind", sngl(vges))
               call nc_diag_data2d("air_temperature", sngl(tsentmp))


### PR DESCRIPTION
Save geometric heights at model levels in ncdiag files in order to interpolate some wind data in a geometric height coordinate in UFO using IODA geoval files created from those ncdiag files.
(NOTE:  I still don't have a chance to run my test about this change on Discover, but it looks fine.) 