### PR TITLE
bring in fix for CO2 options

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/GSI_GridCompMod.F90
+++ b/GEOSaana_GridComp/GSI_GridComp/GSI_GridCompMod.F90
@@ -732,8 +732,9 @@ _ENTRY_(trim(Iam))
 !  if(GsiGridType==0) then  ! equally spaced dgrid
    if(use_sp_eqspace) then  ! equally spaced dgrid
 
-     dlon=(pi+pi)/nlon	! in radians
-     dlat=pi/(nlat-1)
+      dlon=(pi+pi)/nlon	! in radians
+      dlat=pi/(nlat-1)
+
 
 ! Set grid longitude array used by GSI.
       do i=1,nlon			! from 0 to 2pi
@@ -1369,19 +1370,18 @@ _ENTRY_(trim(Iam))
    endif
 #endif
 
+!  Set alarm
+!  ---------
+   call GSI_GridCompSetAnaTime_()
+#ifdef VERBOSE
+   call tell(Iam,"returned from GSI_GridCompSetAnaTime_()")
+#endif
+
    call GSI_GridCompGetPointers_()
    call GSI_GridCompCopyImportDyn2Internal_(L)
    call GSI_GridCompComputeVorDiv_(L)
    call GSI_GridCompCopyImportSfc2Internal_(L)
    call GSI_GridCompGetNCEPsfcFromFile_(L)
-
-!  Set alarm
-!  ---------
-
-   call GSI_GridCompSetAnaTime_()
-#ifdef VERBOSE
-   call tell(Iam,"returned from GSI_GridCompSetAnaTime_()")
-#endif
 
 !  Set observations input
 !  ----------------------

--- a/GEOSaana_GridComp/GSI_GridComp/m_nc_berror.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/m_nc_berror.f90
@@ -90,7 +90,6 @@ subroutine read_dims_ (fname,nlat,nlon,nlev,rc, myid,root)
 
 ! Local variables
   character(len=*), parameter :: myname_ = myname//"::dims_"
-  logical :: verbose
    
 ! Return code (status)
   rc=0; mype_=0; root_=0
@@ -269,7 +268,7 @@ subroutine read_berror_ (fname,bvars,rc, myid,root)
   enddo
   deallocate(data_in)
 
-! Write out lat/lon fields
+! Read in lat/lon fields
   allocate(data_in(nlon,nlat,1))
   do nv = 1, nv2dx
      call check_( nf90_inq_varid(ncid, trim(cvars2dx(nv)), varid), rc, mype_, root_ )
@@ -302,7 +301,7 @@ subroutine write_berror_ (fname,bvars,plevs,lats,lons,rc, myid,root)
   integer, intent(out) :: rc
   integer, intent(in), optional :: myid,root        ! accommodate MPI calling programs
 
-  character(len=*), parameter :: myname_ = myname//"::read_"
+  character(len=*), parameter :: myname_ = myname//"::write_"
   integer, parameter :: NDIMS = 3
 
 ! When we create netCDF files, variables and dimensions, we get back
@@ -377,7 +376,8 @@ subroutine write_berror_ (fname,bvars,plevs,lats,lons,rc, myid,root)
      do nl = 1, nlev
         nn=nn+1
         write(cindx,'(i4.4)') nl
-        call check_( nf90_def_var(ncid, trim(cvarsMLL(nv))//cindx, NF90_REAL, (/ y_dimid, z_dimid /), varidMLL(nn)), rc, mype_, root_ )
+        call check_( nf90_def_var(ncid, trim(cvarsMLL(nv))//cindx, NF90_REAL, (/ y_dimid, z_dimid /), varidMLL(nn)), rc, &
+                     mype_, root_ )
      enddo
   enddo
   allocate(varid2dx(nv2dx))
@@ -482,7 +482,7 @@ subroutine write_berror_ (fname,bvars,plevs,lats,lons,rc, myid,root)
   deallocate(varid2d)
   deallocate(varid1d)
 
-  print *, "*** Finish writing file ", fname
+  if(verbose) print *,"*** Finish writing file: ", trim(fname)
 
   return
 

--- a/GEOSaana_GridComp/GSI_GridComp/ncepgfs_ghg.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/ncepgfs_ghg.f90
@@ -209,7 +209,11 @@ module ncepgfs_ghg
 
       if ( mype == 0 ) then
          write(6,*) ' - Using prescribed co2 global mean value=',co2_glb,&
-            'for Julian Day',julday
+            'for Julian Day',julday, ' on date: ', 10000*iyear+100*month+idd
+      endif
+      if (co2_glb<0.0_r_kind) then
+        write(6,*) ' - Non-sense Co2 value, aborting ...'
+        call stop2(999)
       endif
 
       return
@@ -335,9 +339,6 @@ module ncepgfs_ghg
       if ( mype == 0 ) then
         write(6,*) 'ncep_ghg: CO2 data ',  &
                     'data used for year, month,i,j:',iyear,month,i,j
-        do k=1,nlev
-            write(6,*) ' Level = ',k,' CO2 = ',co2_Tintrp(i,j,k)
-        enddo
       endif
 
 ! Interpolate the co2_Tintrp into a subdomain's grid

--- a/GEOSaana_GridComp/GSI_GridComp/ncepgfs_io.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/ncepgfs_io.f90
@@ -405,20 +405,19 @@ contains
                    ptr3d_co2 = p_co2
                 enddo
              endif
-          else
-             allocate(avefld(size(p_co2,3)))
-             call glbave(p_co2,avefld)
-             if (mype==0) then
-                write(6,'(a)') 'Mean Co2'
-                do k=1,nsig
-                   write(6,'(1p,(e10.3,1x))') avefld(k)
-                enddo
-             endif
-             deallocate(avefld)
           endif
+          allocate(avefld(size(p_co2,3)))
+          call glbave(p_co2,avefld)
+          if (mype==0) then
+             write(6,'(a)') 'Mean Co2'
+             do k=1,nsig
+                write(6,'(1p,(e10.3,1x))') avefld(k)
+             enddo
+          endif
+          deallocate(avefld)
           char_ghg='co2'
-! take comment out for printing out the interpolated tracer gas fields.
-!        call write_ghg_grid (ptr3d_co2,char_ghg)
+! take comment out for printing out final co2 field.
+!         call write_ghg_grid (p_co2,char_ghg)
        endif
     endif ! <co2>
 


### PR DESCRIPTION
Some options for CO2 were not working due to a reversal of lines in GSI_GridComp that attempted to define seasonal co2 option before time was properly set. This is zero diff to present ico2=3 settings anavinfo. Fix allows for options 0 and 2 to work as meant to (ico2 = 1 is not implemented - don't ask me why).