### PR TITLE
PR 130 introduced a bug - fixed now

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -625,6 +625,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
 !       Get guess surface elevation and geopotential height profile 
 !       at observation location.
+        zges = zges_read
 
 !       For observation reported with geometric height above sea level,
 !       convert geopotential to geometric height.


### PR DESCRIPTION
The changes introduced here:

https://github.com/GEOS-ESM/GEOSana_GridComp/pull/130/files

left the zges variable undefined unless the following condition was satisfied.

`if ((itype>=223 .and. itype<=228) .or. sfc_data) then`

From what I see zges should be defined as what the code calls zges_read unless the condition above is met, in which case the values of zges would be redefined as within the "if' statement. 

Since w/o this fix the code will crash under certain conditions - interestingly the default mode of running GSI does not seem to crash, but other modes do -   this change is being labeled as non-zero-diff.