### PR TITLE
Save the original Pressure values read from bufr.

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/setupspd.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupspd.f90
@@ -928,7 +928,7 @@ subroutine setupspd(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
            call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
            call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
            call nc_diag_metadata("Station_Elevation",       sngl(data(istnelv,i))  )
-           call nc_diag_metadata("Pressure",                sngl(presw*r100)       )
+           call nc_diag_metadata("Pressure",                sngl(r1000*exp(data(ipres,i))))
            call nc_diag_metadata("Height",                  sngl(data(ihgt,i))     )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
            call nc_diag_metadata("Prep_QC_Mark",            sngl(data(iqc,i))      )

--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -1764,7 +1764,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
            call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
            call nc_diag_metadata("Station_Elevation",       sngl(data(ielev,i))    )
-           call nc_diag_metadata("Pressure",                sngl(presw*r100)       )
+           call nc_diag_metadata("Pressure",                sngl(r1000*exp(data(ipres,i))))
            call nc_diag_metadata("Height",                  sngl(data(ihgt,i))     )
            call nc_diag_metadata("Time",                    sngl(dtime-time_offset))
            call nc_diag_metadata("LaunchTime",              sngl(data(idft,i))     )


### PR DESCRIPTION
Original pressure values from BUFR are needed for UFO in order to reproduce GSI final observational errors. These values are used to calculate duplicated observation factors for all observation including some surface winds for which those original pressure values are not used for forward processing and GSI diagnosed pressure (presw) values are derived from heights. Since those "presw" are different from original pressure values, UFO duplicator factors are different from those in GSI when "presw" values are used. Therefore, original pressure values need to be saved in nc_diag files.  

In addition, original pressure values are saved in other conventional data nc_diag files.  This change make sure the pressure values are identical for observational temperature and winds, etc. at the same location and time.     