### PR TITLE
Save the original wind_reduction_ractor_at_10m.

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -1788,7 +1788,8 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Error_Input",             sngl(error_input)      )
            call nc_diag_metadata("Error_Adjust",            sngl(error_adjst)      )
 
-           call nc_diag_metadata("Wind_Reduction_Factor_at_10m", sngl(factw)       )
+           call nc_diag_metadata("Wind_Reduction_Factor_at_10m", sngl(data(iff10,i)))
+           call nc_diag_metadata("Wind_Reduction_Scaling_Factor", sngl(factw)       )
 
 
            if(itype >=240 .and. itype <=260) then


### PR DESCRIPTION
Save the wind_reduction_ractor_at_10m which is derived from background in nc_diag files.  Rename the final value "factw" which is the wind_reduction_ractor_at_10m timed by another factor to "Wind_Reduction_Scaling_Factor".

BTW, @rtodling  you don't have to merge this into the tag for x0049 if you already started it.  FV3-JEDI has this geoval variable wind_reduction_ractor_at_10m.