### PR TITLE
Save GSI bias input files for JEDI in analyzer

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/analyzer
+++ b/GEOSaana_GridComp/GSI_GridComp/analyzer
@@ -818,6 +818,7 @@ sub init {
                cp ( "$DIURNAL_SATBIAS/$expid.ana.satbias.${pnymd}_${phh}z.txt", "satbias_in"   );
             } else {
                Assignfn ( "$fvwork/satbias", "satbias_in"   );
+               cp ( "$fvwork/satbias", "$fvwork/satbias_in_for_jedi");
             }
        } else {
             print " Generating satbias_in ... \n";
@@ -831,6 +832,7 @@ sub init {
                cp ( "$DIURNAL_SATBIAS/$expid.ana.satbiaspc.${pnymd}_${phh}z.txt", "satbias_pc"   );
 	   } else {
 	       Assignfn ( "$fvwork/satbiaspc", "satbias_pc"   );
+               cp ( "$fvwork/satbiaspc", "$fvwork/satbiaspc_in_for_jedi");
 	   }
 	   if($ENV{ANGLEBC} && $ENV{DIAGTAR}) {
 	       $cmd = "extract_diagtarfile.csh $fvwork/radstat";
@@ -874,6 +876,7 @@ sub init {
        }
        if ( -e "$fvwork/acftbias" ) {
 	   cp ("$fvwork/acftbias", "aircftbias_in");
+           cp ("$fvwork/acftbias", "$fvwork/aircftbias_in_for_jedi");
        } else {
           $rc_ignore = system("/bin/touch aircftbias_in");
        }


### PR DESCRIPTION
Make copies of GSI radiance and aircraft bias correction input files for running JEDI tests.  Those files are named in the FVWORK directory as: 

satbias_in_for_jedi;
satbiaspc_in_for_jedi;
aircftbias_in_for_jedi.