### PR TITLE
add n21 to FSOI

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_sens.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_sens.rc.tmpl
@@ -178,6 +178,7 @@ OBS_INPUT::
    iasibufr       iasi        metop-c     iasi_metop-c          0.0     3      0        ncep_mtiasi_bufr
    atmsbufr       atms        npp         atms_npp              0.0     1      0        ncep_atms_bufr
    atmsbufr       atms        n20         atms_n20              0.0     1      0        ncep_atms_bufr
+   atmsbufr       atms        n21         atms_n21              0.0     1      0        ncep_atms_bufr
    crisfsrbufr    cris-fsr    npp         cris-fsr_npp          0.0     3      0        ncep_crisfsr_bufr
    crisfsrbufr    cris-fsr    n20         cris-fsr_n20          0.0     3      0        ncep_crisfsr_bufr
    satwndbufr     uv          null        uv                    0.0     0      0        ncep_satwnd_bufr


### PR DESCRIPTION
To fully add NOAA-21 to the system, the data has to also be added to the FSOI component. 

PS: Jianjun, I just noticed you left this from your original https://github.com/GEOS-ESM/GEOSana_GridComp/pull/153