### PR TITLE
Update CRTM to 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add fix to read_bufrtovs to handle ta2tb=.true. when
   there are multiple versions of SpcCoeff.bin file for 
   single instrument/platform
+- update to use CRTM v2.4.1-jedi-1
 
 ### Fixed
 

--- a/GEOSaana_GridComp/GEOSgsi_Coupler/CMakeLists.txt
+++ b/GEOSaana_GridComp/GEOSgsi_Coupler/CMakeLists.txt
@@ -30,7 +30,7 @@ endif ()
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES GEOSagcmPert_GridComp GSI_GridComp Chem_Base nc_diag_write NCEP_crtm fvgcm MAPL
+  DEPENDENCIES GEOSagcmPert_GridComp GSI_GridComp Chem_Base nc_diag_write crtm fvgcm MAPL
   )
 
 target_compile_definitions (${this} PRIVATE GEOS_PERT)

--- a/GEOSaana_GridComp/GSI_GridComp/CMakeLists.txt
+++ b/GEOSaana_GridComp/GSI_GridComp/CMakeLists.txt
@@ -639,7 +639,7 @@ set (WRF_SRCS
    )
 
 set (SRCS
-  ${SRCS_UTIL} ${SRCS_OBSVR} ${SRCS_OTHER} ${SRCS_SOLVER} ${GSIGC_SRCS} prepbykx.f prepbysaid.f
+  ${SRCS_UTIL} ${SRCS_OBSVR} ${SRCS_OTHER} ${SRCS_SOLVER} ${GSIGC_SRCS} prepbykx.f prepbysaid.f test_dec2bin.f90
   )
 
 
@@ -703,6 +703,8 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
             set_source_files_properties (${src} PROPERTIES COMPILE_FLAGS "${GEOS_Fortran_Release_Flags} ${common_Fortran_flags} ${BYTERECLEN} ${EXTENDED_SOURCE} ${FP_MODEL_STRICT} ${ALIGNCOM}")
          elseif (${src} MATCHES prepbysaid.f)
             set_source_files_properties (${src} PROPERTIES COMPILE_FLAGS "${GEOS_Fortran_Release_Flags} ${common_Fortran_flags} ${BYTERECLEN} ${EXTENDED_SOURCE} ${FP_MODEL_STRICT} ${ALIGNCOM}")
+         elseif (${src} MATCHES test_dec2bin.f90)
+            set_source_files_properties (${src} PROPERTIES COMPILE_FLAGS "${GEOS_Fortran_Release_Flags} ${common_Fortran_flags} ${BYTERECLEN} ${EXTENDED_SOURCE} ${FP_MODEL_STRICT} ${ALIGNCOM}")
          elseif (${src} MATCHES m_gsiversion.F90)
             set_source_files_properties (${src} PROPERTIES COMPILE_FLAGS "${GEOS_Fortran_Release_Flags} ${common_Fortran_flags} ${BIG_ENDIAN} ${BYTERECLEN}")
          elseif (${src} MATCHES crtm_interface.f90)
@@ -721,7 +723,7 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
 endif ()
 
 if (EXTENDED_SOURCE)
-  set_source_files_properties(prepbykx.f prepbysaid.f PROPERTIES COMPILE_OPTIONS ${EXTENDED_SOURCE})
+  set_source_files_properties(prepbykx.f prepbysaid.f test_dec2bin.f90 PROPERTIES COMPILE_OPTIONS ${EXTENDED_SOURCE})
 endif ()
 
 set (SRCS_STUBS
@@ -792,3 +794,4 @@ endforeach()
 
 ecbuild_add_executable(TARGET prepbykx.x SOURCES prepbykx.f LIBS ${this})
 ecbuild_add_executable(TARGET prepbysaid.x SOURCES prepbysaid.f LIBS ${this})
+ecbuild_add_executable(TARGET test_dec2bin.x SOURCES test_dec2bin.f90 LIBS ${this})

--- a/GEOSaana_GridComp/GSI_GridComp/CMakeLists.txt
+++ b/GEOSaana_GridComp/GSI_GridComp/CMakeLists.txt
@@ -749,11 +749,11 @@ install(
   
 esma_add_library (GSI_GridComp
    SRCS ${SRCS_UTIL} ${SRCS_OBSVR} ${SRCS_OTHER} ${SRCS_SOLVER} ${GSIGC_SRCS} 
-  DEPENDENCIES MAPL NCEP_crtm NCEP_w3_r8i4 NCEP_bufr_r8i4 NCEP_sigio NCEP_gfsio NCEP_nemsio nc_diag_read nc_diag_write NCEP_sfcio GMAO_hermes GMAO_transf)
+  DEPENDENCIES MAPL crtm NCEP_w3_r8i4 NCEP_bufr_r8i4 NCEP_sigio NCEP_gfsio NCEP_nemsio nc_diag_read nc_diag_write NCEP_sfcio GMAO_hermes GMAO_transf)
 
 esma_add_library (GSI_GridComp_with_stubs
    SRCS ${SRCS_STUBS} ${SRCS_UTIL} ${SRCS_OBSVR} ${SRCS_OTHER} ${SRCS_SOLVER} ${GSIGC_SRCS} 
-   DEPENDENCIES MAPL NCEP_crtm NCEP_w3_r8i4 NCEP_bufr_r8i4 NCEP_sigio NCEP_gfsio NCEP_nemsio nc_diag_read nc_diag_write NCEP_sfcio GMAO_hermes GMAO_transf)
+   DEPENDENCIES MAPL crtm NCEP_w3_r8i4 NCEP_bufr_r8i4 NCEP_sigio NCEP_gfsio NCEP_nemsio nc_diag_read nc_diag_write NCEP_sfcio GMAO_hermes GMAO_transf)
 
 foreach (item HAVE_ESMF _SKIP_READ_OBS_CHECK_ _TIMER_ON_ _REAL8_)
    target_compile_definitions (GSI_GridComp PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${item}>)
@@ -772,7 +772,7 @@ endforeach()
 
 #esma_add_library (GSI_Util
 #  SRCS ${SRCS_UTIL}
-#  DEPENDENCIES GSI_Observer MAPL NCEP_crtm NCEP_nemsio nc_diag_read GMAO_stoch)  
+#  DEPENDENCIES GSI_Observer MAPL crtm NCEP_nemsio nc_diag_read GMAO_stoch)  
 #
 #esma_add_library (GSI_Observer
 #  SRCS ${SRCS_OBSVR}

--- a/GEOSaana_GridComp/GSI_GridComp/analyzer
+++ b/GEOSaana_GridComp/GSI_GridComp/analyzer
@@ -181,6 +181,7 @@
 #  20May2020 Todling/JG - update CRTM coeffs to point to fix_ncep20200513 (to allow for CrIS FSR)
 #  30Nov2020 Guo/MC/MS - add program to rescale values in satbias_pc file for specified date/sis/channels
 #  28May2021 JG/MJK/RT - update CRTM coeffs to point to fix_ncep20210525 (to allow for IASI Metop-C)
+#  09Oct2021 Todling - CRTM coeffs now in sync with those used in GMAO-JEDI: JEDI-CRTM-2.4.1j1-GMAO
 #-----------------------------------------------------------------------------------------------------
 
 use Env;                 # make env vars readily available
@@ -649,8 +650,7 @@ sub init {
    if ( $ENV{CRTM_COEFFS} ) {
       Assignfn( "$CRTM_COEFFS","CRTM_Coeffs");
    } else {
-#     Assignfn( "$fvInput/$myetc/fix_ncep20221018/REL-2.4.0-jcsda/CRTM_Coeffs/Little_Endian","CRTM_Coeffs");
-      Assignfn( "$fvInput/$myetc/r21c_ncep20221018/Little_Endian","CRTM_Coeffs");
+      Assignfn( "$fvInput/$myetc/JEDI-CRTM-2.4.1j1-GMAO/Little_Endian","CRTM_Coeffs");
    }
    Assignfn( "$fvhome/run/prepobs_errtable.global","errtable");
 

--- a/GEOSaana_GridComp/GSI_GridComp/ensctl2state.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/ensctl2state.f90
@@ -138,7 +138,7 @@ do_cw_to_hydro_hwrf = .false.
 do_cw_to_hydro_hwrf = lc_cw.and.ls_ql.and.ls_qi.and.ls_qr.and.ls_qs.and.ls_qg.and.ls_qh
 
 ! Initialize ensemble contribution to zero
-!$omp parallel do schedule(dynamic,1) private(jj)
+!_$omp parallel do schedule(dynamic,1) private(jj)
 do jj=1,ntlevs_ens 
    eval(jj)%values=zero
 end do
@@ -168,9 +168,9 @@ do jj=1,ntlevs_ens
    call gsi_bundlegetpointer (eval(jj),'u'   ,sv_u,   istatus)
    call gsi_bundlegetpointer (eval(jj),'v'   ,sv_v,   istatus)
    call gsi_bundlegetpointer (eval(jj),'tsen',sv_tsen,istatus)
-!$omp parallel sections private(ic,id,istatus)
+!_$omp parallel sections private(jj,ic,id,istatus)
 
-!$omp section
+!_$omp section
 
 !  Get pointers to required state variables
 !  Convert streamfunction and velocity potential to u,v
@@ -185,7 +185,7 @@ do jj=1,ntlevs_ens
       end if
    end if
 
-!$omp section
+!_$omp section
 
 !  Copy variables
    call gsi_bundlegetvar ( wbundle_c, 't'  , sv_tv,  istatus )
@@ -226,7 +226,7 @@ do jj=1,ntlevs_ens
    endif
 
 
-!$omp section
+!_$omp section
 
 !  Get pointers to required state variables
    call gsi_bundlegetpointer (eval(jj),'oz'  ,sv_oz , istatus)
@@ -247,7 +247,7 @@ do jj=1,ntlevs_ens
       end if
    end if
 
-!$omp end parallel sections
+!_$omp end parallel sections
 
 ! Add contribution from static B, if necessary
    call self_add(eval(jj),mval)

--- a/GEOSaana_GridComp/GSI_GridComp/ensctl2state_ad.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/ensctl2state_ad.f90
@@ -177,9 +177,9 @@ do jj=1,ntlevs_ens
 
    call self_add(mval,eval(jj))
 
-!$omp parallel sections private(ic,id,istatus)
+!_$omp parallel sections private(ic,id,istatus)
 
-!$omp section
+!_$omp section
 
 !  Convert RHS calculations for u,v to st/vp
    if (do_getuv) then
@@ -193,7 +193,7 @@ do jj=1,ntlevs_ens
       end if
    end if
 
-!$omp section
+!_$omp section
 
    call gsi_bundlegetpointer (eval(jj),'oz'  ,rv_oz , istatus)
    call gsi_bundlegetpointer (eval(jj),'sst' ,rv_sst, istatus)
@@ -208,7 +208,7 @@ do jj=1,ntlevs_ens
      end if
    end if
 
-!$omp section
+!_$omp section
 
    if (do_cw_to_hydro_ad .and. .not.do_cw_to_hydro_ad_hwrf) then
 !     Case when cloud-vars do not map one-to-one
@@ -246,7 +246,7 @@ do jj=1,ntlevs_ens
    call gsi_bundleputvar ( wbundle_c, 't' ,  rv_tv,  istatus )
    call gsi_bundleputvar ( wbundle_c, 'ps',  rv_ps,  istatus )
 !  call gsi_bundleputvar ( wbundle_c, 'q' ,  zero,   istatus )                  
-!$omp end parallel sections
+!_$omp end parallel sections
 
    if(dual_res) then
       call ensemble_forward_model_ad_dual_res(wbundle_c,grad%aens(1,:),jj)

--- a/GEOSaana_GridComp/GSI_GridComp/etc/check_satbang.py
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/check_satbang.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob, os, re, sys
 

--- a/GEOSaana_GridComp/GSI_GridComp/setuprad.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setuprad.f90
@@ -2682,6 +2682,7 @@ contains
                  call nc_diag_metadata("Forecast_unadjusted_clear",     sngl(tsim_clr(ich_diag(i))))     ! simulated Tb under clear-sky condition
                  call nc_diag_metadata("Forecast_adjusted_clear",       sngl(tsim_clr_bc(ich_diag(i))))     ! simulated Tb under clear-sky condition
                  call nc_diag_metadata("Forecast_unadjusted",           sngl(tb_obs(ich_diag(i))-tbcnob(ich_diag(i)))) ! simulated Tb with no bias correction
+                 call nc_diag_metadata("Forecast_adjusted",             sngl(tb_obs(ich_diag(i))-tbc(ich_diag(i)))     ) ! simulated Tb with bias correction
            !     call nc_diag_metadata("Bias_Correction", sngl(tbc(ich_diag(i))-tbcnob(ich_diag(i)))       ) ! bias correction
                  call nc_diag_metadata("Bias_Correction", sngl(tbcnob(ich_diag(i))-tbc(ich_diag(i)))       ) ! bias correction
                  call nc_diag_metadata("Bias_Correction_Constant", sngl(predbias(1,ich_diag(i)))           ) ! constant bias correction

--- a/GEOSaana_GridComp/GSI_GridComp/setuprad.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setuprad.f90
@@ -593,18 +593,18 @@ contains
      obstype,nchanl,' --> ',jc
   if(jc == 0 .or. toss)then 
      if(jc == 0 .and. mype == 0) then
-        write(6,*)'SETUPRAD: No channels found for ', obstype,isis
+        write(6,*)'SETUPRAD: No channels found for ', trim(obstype),trim(isis)
      end if
      if (toss .and. mype == 0) then
         write(6,*)'SETUPRAD: all obs var > 1e4.  do not use ',&
-           'data from satellite is=',isis
+           'data from satellite is=',trim(isis)
      endif
 
      if(nobs >0)read(lunin)                    
      return
   endif
 
-  if ( mype == 0 .and. .not.l_may_be_passive) write(6,*)mype,'setuprad: passive obs',is,isis
+  if ( mype == 0 .and. .not.l_may_be_passive) write(6,*)mype,'setuprad: passive obs',is,trim(isis)
 
 !  Logic to turn off print of reading coefficients if not first interation or not mype_diaghdr or not init_pass
   iwrmype=-99
@@ -703,7 +703,7 @@ contains
            endif
         enddo
         if (no85GHz .and. mype == 0) write(6,*) &
-           'SETUPRAD: using no85GHZ workaround for SSM/I ',isis
+           'SETUPRAD: using no85GHZ workaround for SSM/I ',trim(isis)
      endif
   endif
 

--- a/GEOSaana_GridComp/GSI_GridComp/test_dec2bin.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/test_dec2bin.f90
@@ -1,0 +1,90 @@
+program test_dec2bin
+
+implicit none
+
+integer,parameter :: i_kind = 4
+integer,parameter :: mdim = 5
+integer,parameter :: ndim = 10
+integer(i_kind) :: dec(mdim)
+integer(i_kind) :: bin(ndim)
+
+integer ii,input
+
+dec(1) = -2
+dec(2) = -1
+dec(3) =  1
+dec(4) =  0 
+dec(5) = 31
+
+
+print *, ' dec   bin '
+do ii = 1,mdim
+  input = dec(ii)
+  call dec2bin_(dec(ii),bin,ndim)
+  print*, input, dec(ii), bin
+  print* 
+enddo
+
+
+contains
+subroutine dec2bin_(dec,bin,ndim)
+
+!$$$  subprogram documentation block
+!                .      .    .                                       .
+! subprogram:    dec2bin                  convert decimal number to binary
+!   prgmmr: unknown             org: np23                date: 2010-04-06
+!
+! abstract:  This routine convert a decimal number to binary
+!
+! program history log:
+!   2010-04-06  hliu
+!   2013-02-05  guo  - STOP in dec2bin() was replaced with die() to signal an _abort_.
+!
+!   input argument list:
+!     dec  - observation type to process
+!
+!   output argument list:
+!     bin    - number of sbuv/omi ozone observations read
+!
+! remarks:
+!
+! attributes:
+!   language: f90
+!   machine:  ibm RS/6000 SP
+!
+
+!   use kinds, only: i_kind
+!   use mpeu_util, only: die, perr
+
+    implicit none
+
+! Declare passed variables
+    integer(i_kind) ,intent(inout) :: dec
+    integer(i_kind) ,intent(in)    :: ndim
+    integer(i_kind) ,intent(out)   :: bin(ndim)
+
+! Declare local variables
+    integer(i_kind):: bindec, i
+
+!   Check to determine decimal # is within bounds
+    i = ndim
+    IF ((dec - 2**i) >= 0) THEN
+       write(6,*) 'Error: Decimal Number too Large. Must be < 2^(',ndim-1,')'
+       stop 99
+    END IF
+
+!   Determine the scalar for each of the decimal positions
+    DO WHILE (i >= 1)
+       bindec = 2**(i-1)
+       IF ((dec - bindec) >= 0) THEN
+          bin(i) = 1
+          dec = dec - bindec
+       ELSE
+          bin(i) = 0
+       END IF
+       i = i - 1
+    END DO
+    RETURN
+END subroutine dec2bin_
+
+end program test_dec2bin


### PR DESCRIPTION
The changes related to CRTM are those in the CMakelist since the lib has changed name - from libNCEP_crtm.a to libcrtm.a 

The changes must be coordinated w/ changes in the GEOSadas fixture: 

Now, in the process of doing to conversion for GSI can use the same version of CRTM that GMAO-JEDI is presently (Oct 2014)  a few things were issues that needed tackling:

1) Somehow the hybrid 4d option fails due to an OpenMP issue; I believe the OpenMP changes introduced in CRTM 2.4.1 are such that code behaves differently even when number of threads is one. I found necessary to comment out openMP in two of the control to state routines associated w/ the ensemble. This should not be an issue since no threads are being used anyway.

2) The idea of this change is also so that we can have both JEDI and GSI point to the same CRTM coefficients location. This however will need some adjustment because of the following:

2a) the CloudCoeff.bin file used in CRTM 2.4.1 is inconsistent w/ what GMAO uses, namely:  CloudCoeffs_MJKim-type5-20171130.bin

2b) the file:  amsua_metop-c.SpcCoeff.bin in 2.4.1 does not allow running the option TA2TB=.true. in GSI; somehow the code crashes on the file that's in the official release of the coeffs. So this also needs replacing w/ what we've been using at GMAO, particularly, M21C.


3 Another issue encountered is that the hirs4 files in the 2.4.1 release are not consistent w/ what CRTM 2.4.1 expects - this is apparently a known bug ... since we are not using HIRS4 in any of our current uses of GEOSadas aimed at FP, this will be an issue addressed later in another PR.

