### PR TITLE
Increase max_tail buffer size for aircraft to accommodate increase

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/aircraftinfo.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/aircraftinfo.f90
@@ -56,7 +56,7 @@ module aircraftinfo
   logical :: cleanup_tail ! logical to remove tail number no longer used
   logical :: upd_aircraft ! indicator if update bias at 06Z & 18Z
   
-  integer(i_kind), parameter :: max_tail=15000  ! max tail numbers
+  integer(i_kind), parameter :: max_tail=20000  ! max tail numbers
   integer(i_kind) npredt          ! predictor number
   integer(i_kind) ntail           ! total tail number
   integer(i_kind) ntail_update    ! new total tail number


### PR DESCRIPTION
Increase max_tail buffer size for aircraft to accommodate increase in tails due to addition of ADS-C data from non-U.S. aircraft to the input data stream.  ESMA (progress) ticket #2454.  Added to FP 20241102 18z.

Note FP had had a max tail number set to 11000 and develop has 15000 already so it may not be urgent to change unless we want to keep things consistent with FP.    Currently the count of lines in the ana.acftbias file is 11547 and slowly growing.

This should be zero diff - until there are too many unique aircraft tails to store in the coefficient arrays.


