### PR TITLE
Missing in N21 PR

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsidiags.rc
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsidiags.rc
@@ -32,6 +32,7 @@ avhrr_n19
 cris_npp
 cris-fsr_npp
 cris-fsr_n20
+cris-fsr_n21
 gmi_gpm
 goes_n08
 goes_n10


### PR DESCRIPTION
This was missing in the original PR released to cris-fsr-n21. Needed for creating proper silo.arc and others.

Thanks for Wei for spotting the missing silo arc entry.