### PR TITLE
Accommodate JEDI GeoVals name changes (Oct24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+12Dec2024:
+- updates GeoVals falling the Oct 2024 JEDI variable name change code sprint.
+- bug fix in setupbend to allow running old flavor of pressure/integration option.
+- add operationally-named class for OMPS-LP from NPP has been added to gsi.rc.tmpl and gsi_sens.rc.tmpl
+
+------------------------------------------------------
 - add ability to convert antenna to brigtness temperature
 - bugfix: update calculation of div/vor
 - merge of 5.30.3 with 5.40.0 and 5.29.5-p7

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi.rc.tmpl
@@ -151,6 +151,8 @@ OBS_INPUT::
 !  mlsoz          o3lev       aura        mls_aura_ozlv         0.0     0      0        test
 !  mlsozbufr      o3lev       aura        o3lev_aura            0.0     0      0        test
 !  ompslpgnc      ompslpnc    npp         ompslpnc_npp          1.0     0      0        ompslpnc_nc
+! NOTE: careful not to have both npp_ompslp_nc and r21c_npp_ompslp_nc in obsclass
+   ompslpnppnc    ompslpnc    npp         ompslpnc_npp          1.0     0      0        npp_ompslp_nc
    ompslpnppnc    ompslpnc    npp         ompslpnc_npp          1.0     0      0        r21c_npp_ompslp_nc
    ompslpn21nc    ompslpnc    n21         ompslpnc_n21          1.0     0      0        m2scr_n21_ompslp_nc
    ompslpuvnc     ompslpuv    npp         ompslpuv_npp          1.0     0      0        ompslpuv_nc

--- a/GEOSaana_GridComp/GSI_GridComp/etc/gsi_sens.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/gsi_sens.rc.tmpl
@@ -157,6 +157,8 @@ OBS_INPUT::
 !  mlsoz          o3lev       aura        mls_aura_ozlv         0.0     0      0        test
 !  mlsozbufr      o3lev       aura        o3lev_aura            0.0     0      0        test
 !  ompslpgnc      ompslpnc    npp         ompslpnc_npp          1.0     0      0        ompslpnc_nc
+! NOTE: careful not to have both npp_ompslp_nc and r21c_npp_ompslp_nc in obsclass
+   ompslpnppnc    ompslpnc    npp         ompslpnc_npp          1.0     0      0        npp_ompslp_nc
    ompslpnppnc    ompslpnc    npp         ompslpnc_npp          1.0     0      0        r21c_npp_ompslp_nc
    ompslpn21nc    ompslpnc    n21         ompslpnc_n21          1.0     0      0        m2scr_n21_ompslp_nc
    ompslpuvnc     ompslpuv    npp         ompslpuv_npp          1.0     0      0        ompslpuv_nc

--- a/GEOSaana_GridComp/GSI_GridComp/genstats_gps.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/genstats_gps.f90
@@ -808,11 +808,11 @@ subroutine contents_netcdf_diag_
 
 !          geovals
            call nc_diag_metadata("surface_altitude",           sngl(gps_allptr%rdiag(9)) )
-           call nc_diag_metadata("surface_geopotential_height",sngl(gps_allptr%rdiag(9)) )
+           call nc_diag_metadata("geopotential_height_at_surface",sngl(gps_allptr%rdiag(9)) )
            if (wrtgeovals) then
               call nc_diag_data2d("air_temperature",              sngl(gps_allptr%tsenges) )
               call nc_diag_data2d("virtual_temperature",          sngl(gps_allptr%tvirges) )
-              call nc_diag_data2d("specific_humidity",            sngl(gps_allptr%sphmges) )
+              call nc_diag_data2d("water_vapor_mixing_ratio_wrt_moist_air", sngl(gps_allptr%sphmges) )
               call nc_diag_data2d("geopotential_height",          sngl(gps_allptr%hgtlges) )
               call nc_diag_data2d("geopotential_height_levels",   sngl(gps_allptr%hgtiges) )
               call nc_diag_data2d("atmosphere_pressure_coordinate_interface",  sngl(gps_allptr%prsiges) )

--- a/GEOSaana_GridComp/GSI_GridComp/setupaod.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupaod.f90
@@ -851,7 +851,7 @@ contains
             do k=1,nsig
                tmp(k)=qvp(nsig-k+1)/(1_r_kind-qvp(nsig-k+1))
             end do
-            call nc_diag_data2d("humidity_mixing_ratio", tmp(1:nsig))  ! kg/kg  
+            call nc_diag_data2d("water_vapor_mixing_ratio_wrt_dry_air", tmp(1:nsig))  ! kg/kg  
      
             do k=1,nsig
                tmp(k)=rh(nsig-k+1)

--- a/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
@@ -471,24 +471,27 @@ subroutine setupbend(obsLL,odiagLL, &
           nsig,mype,nfldsig)
      call tintrp2a11(ges_z,zsges,dlat,dlon,dtime,hrdifsig,&
           mype,nfldsig)
- !    Interpolate mid-level log(pres),mid-level geopotential height,
- !    and air temperature for JEDI
+ !   Interpolate mid-level log(pres),mid-level geopotential height,
+ !   and air temperature for JEDI
      call tintrp2a1(ges_tsen,  Tsen(1:nsig,i),  dlat,dlon,dtime,hrdifsig, &
           nsig, mype,nfldsig)
      call tintrp2a1(ges_lnprsl,prstmpl(1:nsig),dlat,dlon,dtime,hrdifsig,&
           nsig, mype,nfldsig)
+
+! GeoVals stuff:
+     Tvir(1:nsig,i)      = tges(1:nsig)            ! virtual temperature
+     sphm(1:nsig,i)      = qges(1:nsig)            ! specific humidity
+     hgtl(1:nsig,i)      = hges(1:nsig) + zsges    ! mid level geopotential height
+     hgti(1:nsig+1,i)    = hgesi(1:nsig+1) + zsges ! interface level geopotential height
+     prslni(1:nsig+1,i)  = prsltmp(1:nsig+1)       ! interface level log(pressure)
+     prslnl(1:nsig,i)    = prstmpl(1:nsig)         !  mid level log(pressure)
+
      if (lgpsbnd_revint) then
         prsltmp_o(1:nsig,i)=prstmpl(1:nsig) ! needed in minimization
      else
+        hges(1:nsig) = hgesi(1:nsig)
         prsltmp_o(1:nsig,i)=prsltmp(1:nsig) ! needed in minimization
      endif
-
-      Tvir(1:nsig,i)      = tges(1:nsig)            ! virtual temperature
-      sphm(1:nsig,i)      = qges(1:nsig)            ! specific humidity
-      hgtl(1:nsig,i)      = hges(1:nsig) + zsges    ! mid level geopotential height
-      hgti(1:nsig+1,i)    = hgesi(1:nsig+1) + zsges ! interface level geopotential height
-      prslni(1:nsig+1,i)  = prsltmp(1:nsig+1)       ! interface level log(pressure)
-      prslnl(1:nsig,i)    = prstmpl(1:nsig)         !  mid level log(pressure)
 
 ! Compute refractivity index-radius product at interface
 !

--- a/GEOSaana_GridComp/GSI_GridComp/setupps.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupps.f90
@@ -1075,20 +1075,20 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            endif
            ! geovals for JEDI UFO
            if (wrtgeovals) then
-              call nc_diag_metadata("surface_geopotential_height", sngl(zsges))
-              call nc_diag_metadata("surface_pressure", sngl(pgesorig*r100))
+              call nc_diag_metadata("geopotential_height_at_surface", sngl(zsges))
+              call nc_diag_metadata("air_pressure_at_surface", sngl(pgesorig*r100))
               !call nc_diag_metadata("surface_height", sngl())
               !call nc_diag_metadata("2m_temperature", sngl(tgges))
-              !call nc_diag_metadata("2m_specific_humidity", sngl())
+              !call nc_diag_metadata("water_vapor_mixing_ratio_wrt_moist_air_at_2m", sngl())
               call nc_diag_data2d("geopotential_height", sngl(zges))
               call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp2*r1000))
               call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
               call nc_diag_data2d("virtual_temperature", sngl(tvgestmp))
               call nc_diag_data2d("air_temperature", sngl(tsentmp))
-              call nc_diag_data2d("specific_humidity", sngl(qtmp))
+              call nc_diag_data2d("water_vapor_mixing_ratio_wrt_moist_air", sngl(qtmp))
               call nc_diag_data2d("northward_wind", sngl(utmp))
               call nc_diag_data2d("eastward_wind", sngl(vtmp))
-              call nc_diag_metadata("surface_temperature", sngl(tges))
+              call nc_diag_metadata("air_temperature_at_2m", sngl(tges))
            endif
            call nc_diag_metadata("surface_roughness", sngl(sfcr/r100))
            call nc_diag_metadata("landmask", sngl(landfrac))

--- a/GEOSaana_GridComp/GSI_GridComp/setupq.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupq.f90
@@ -1384,16 +1384,16 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            endif
            ! geovals for JEDI UFO
            if (wrtgeovals) then
-              call nc_diag_metadata("surface_geopotential_height", sngl(zsges))
-              call nc_diag_metadata("surface_pressure", sngl(psges*r1000))
-              call nc_diag_metadata("surface_temperature", sngl(sfctges))
+              call nc_diag_metadata("geopotential_height_at_surface", sngl(zsges))
+              call nc_diag_metadata("air_pressure_at_surface", sngl(psges*r1000))
+              call nc_diag_metadata("air_temperature_at_2m", sngl(sfctges))
               call nc_diag_data2d("geopotential_height", sngl(zges))
               call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp2*r1000))
               call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
               call nc_diag_data2d("virtual_temperature", sngl(tvgestmp))
               call nc_diag_data2d("air_temperature", sngl(tsentmp))
               call nc_diag_data2d("saturated_specific_humidity_profile", sngl(qsat_ges))
-              call nc_diag_data2d("specific_humidity", sngl(qtmp))
+              call nc_diag_data2d("water_vapor_mixing_ratio_wrt_moist_air", sngl(qtmp))
               call nc_diag_data2d("northward_wind", sngl(utmp))
               call nc_diag_data2d("eastward_wind", sngl(vtmp))
               call nc_diag_data2d("dup_kx_vector", sngl(dup_kx_vector(:,i)))

--- a/GEOSaana_GridComp/GSI_GridComp/setupt.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupt.f90
@@ -1780,16 +1780,15 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     endif
     ! geovals for JEDI UFO
     if (wrtgeovals) then
-       call nc_diag_metadata("surface_temperature", sngl(sfctges))
-       call nc_diag_metadata("surface_geopotential_height",sngl(zsges))
-       call nc_diag_metadata("surface_pressure",sngl(psges*r1000))
-       call nc_diag_metadata("surface_temperature", sngl(sfctges))
+       call nc_diag_metadata("air_temperature_at_2m", sngl(sfctges))
+       call nc_diag_metadata("geopotential_height_at_surface",sngl(zsges))
+       call nc_diag_metadata("air_pressure_at_surface",sngl(psges*r1000))
        call nc_diag_data2d("geopotential_height", sngl(zges))
        call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp3*r1000))
        call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
        call nc_diag_data2d("virtual_temperature", sngl(tvgestmp))
        call nc_diag_data2d("air_temperature", sngl(tsentmp))
-       call nc_diag_data2d("specific_humidity", sngl(qgestmp))
+       call nc_diag_data2d("water_vapor_mixing_ratio_wrt_moist_air", sngl(qgestmp))
        call nc_diag_data2d("eastward_wind", sngl(ugestmp))
        call nc_diag_data2d("northward_wind", sngl(vgestmp))
        call nc_diag_data2d("dup_kx_vector", sngl(dup_kx_vector(:,i)))

--- a/GEOSaana_GridComp/GSI_GridComp/setuptcp.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setuptcp.f90
@@ -722,7 +722,7 @@ subroutine setuptcp(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diags
            if (wrtgeovals) then
              call nc_diag_data2d("virtual_temperature", tvges)
              call nc_diag_metadata("surface_air_pressure", psges )
-             call nc_diag_metadata("surface_geopotential_height", zsges )
+             call nc_diag_metadata("geopotential_height_at_surface", zsges )
            endif
 
   end subroutine contents_netcdf_diag_

--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -1908,18 +1908,18 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_data2d("v_Observation_Operator_Jacobian_val", real(dhx_dx_v%val,r_single))
            endif
            if (wrtgeovals) then
-              call nc_diag_metadata("surface_pressure",sngl(psges*r1000))
-              call nc_diag_metadata("surface_geopotential_height",sngl(zsges))
-              call nc_diag_metadata("surface_temperature", sngl(sfctges))
+              call nc_diag_metadata("air_pressure_at_surface",sngl(psges*r1000))
+              call nc_diag_metadata("geopotential_height_at_surface",sngl(zsges))
+              call nc_diag_metadata("air_temperature_at_2m", sngl(sfctges))
               call nc_diag_data2d("atmosphere_pressure_coordinate", sngl(prsltmp2*r1000))
               call nc_diag_data2d("atmosphere_pressure_coordinate_interface", sngl(prsitmp*r1000))
               call nc_diag_data2d("virtual_temperature", sngl(tges))
               call nc_diag_data2d("geopotential_height", sngl(zges_read))
-              call nc_diag_data2d("geometric_height", sngl(zges_geometric))
+              call nc_diag_data2d("height_above_mean_sea_level", sngl(zges_geometric))
               call nc_diag_data2d("eastward_wind", sngl(uges))
               call nc_diag_data2d("northward_wind", sngl(vges))
               call nc_diag_data2d("air_temperature", sngl(tsentmp))
-              call nc_diag_data2d("specific_humidity", sngl(qges))
+              call nc_diag_data2d("water_vapor_mixing_ratio_wrt_moist_air", sngl(qges))
               call nc_diag_data2d("dup_kx_vector", sngl(dup_kx_vector(:,i)))
            endif
            call nc_diag_metadata("Dominant_Sfc_Type", sngl(data(idomsfc,i))           )


### PR DESCRIPTION
This updates various GeoVals falling the Oct 2024 JEDI variable name change code sprint.

This also includes a fix in setupbend - changes introduced PR #117 broke the old (NCEP) mode of running GPSRO - that is, not using the currently used fix from Ron Errico, Hui Shan and Nikki Prive.

Furthermore, the operationally-named class for OMPS-LP from NPP has been added to gsi.rc.tmpl and gsi_sens.rc.tmpl - eventually I would like to remove the r21c class that's been added to allow running x0050. No x-experiment should be posting to R/M21C input data; it becomes confusing.