### PR TITLE
Stopgap for handling 20 veg types

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/CMakeLists.txt
+++ b/GEOSaana_GridComp/GSI_GridComp/CMakeLists.txt
@@ -753,11 +753,11 @@ install(
   
 esma_add_library (GSI_GridComp
    SRCS ${SRCS_UTIL} ${SRCS_OBSVR} ${SRCS_OTHER} ${SRCS_SOLVER} ${GSIGC_SRCS} 
-  DEPENDENCIES MAPL crtm NCEP_w3_r8i4 NCEP_bufr_r8i4 NCEP_sigio NCEP_gfsio NCEP_nemsio nc_diag_read nc_diag_write NCEP_sfcio GMAO_hermes GMAO_transf)
+  DEPENDENCIES MAPL crtm NCEP_w3_r8i4 NCEP_bufr_r8i4 NCEP_sigio NCEP_gfsio NCEP_nemsio nc_diag_read nc_diag_write NCEP_sfcio GMAO_hermes )
 
 esma_add_library (GSI_GridComp_with_stubs
    SRCS ${SRCS_STUBS} ${SRCS_UTIL} ${SRCS_OBSVR} ${SRCS_OTHER} ${SRCS_SOLVER} ${GSIGC_SRCS} 
-   DEPENDENCIES MAPL crtm NCEP_w3_r8i4 NCEP_bufr_r8i4 NCEP_sigio NCEP_gfsio NCEP_nemsio nc_diag_read nc_diag_write NCEP_sfcio GMAO_hermes GMAO_transf)
+   DEPENDENCIES MAPL crtm NCEP_w3_r8i4 NCEP_bufr_r8i4 NCEP_sigio NCEP_gfsio NCEP_nemsio nc_diag_read nc_diag_write NCEP_sfcio GMAO_hermes )
 
 foreach (item HAVE_ESMF _SKIP_READ_OBS_CHECK_ _TIMER_ON_ _REAL8_)
    target_compile_definitions (GSI_GridComp PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${item}>)

--- a/GEOSaana_GridComp/GSI_GridComp/GSI_GridCompMod.F90
+++ b/GEOSaana_GridComp/GSI_GridComp/GSI_GridCompMod.F90
@@ -2680,9 +2680,10 @@ _ENTRY_(trim(Iam))
            version=1776 ! just give it a number
            call nc_ncepsfc_read('ncepsfc',sfcvars,STATUS)
            VERIFY_(status)
-           if(sfcvars%nveg/=nvege_type) then
+           if(abs(sfcvars%nveg-nvege_type)>1) then
              status=99
-             VERIFY_(STATUS)
+             print*, trim(Iam), 'Failed to read ncep nc sfc file, : ', sfcvars%nveg, nvege_type
+             call stop2(status)
            endif
            glon =size(sfcvars%vfrac,1)
            glat2=size(sfcvars%vfrac,2)

--- a/GEOSaana_GridComp/GSI_GridComp/m_nc_ncepsfc.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/m_nc_ncepsfc.f90
@@ -170,7 +170,7 @@ subroutine read_ncepsfc_ (fname,sfcvar,rc, myid,root)
   enddo
   deallocate(data_in)
 
-  sfcvar%nveg = nint(maxval(sfcvar%vtype))+1
+  sfcvar%nveg = nint(maxval(sfcvar%vtype))
 
 ! Close the file, freeing all resources.
   call check_( nf90_close(ncid), rc, mype_, root_ )


### PR DESCRIPTION
It turns out the "ncep-sfc" file that ran x0051  has an incorrect number of surface types (19 as opposed to 20) due to the voting scheme used to convert the original data into the resolution of GEOS - the file corresponding to 1152x721 is correct, but not that for 576x361 - to preserve reproducibility w/ x0051 I placed a stopgap in the code to allow handling of the incorrect number of types ... a follow up revision will correct the input data (but it won't be zero diff).

This also removes referencing too GMAO_transf in the make procedure since this lib is not needed and introduced various issues associated w/ the loader.