### PR TITLE
FSI weights must be applied for all outer loops

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupbend.f90
@@ -1359,7 +1359,7 @@ subroutine setupbend(obsLL,odiagLL, &
            endif
 
            my_head%raterr2= ratio_errors(i)**2
-           if (fsi_weight .and. jiter==jiterstart) then
+           if (fsi_weight) then
              ! Adjustment of omb residual following FSI
              call fsi_apply_weight(sfactor,'gps',nint(data(isatid,i)),data(ilate,i),data(ilone,i),ten*exp(dpressure))
              my_head%res    = sfactor*data(igps,i)

--- a/GEOSaana_GridComp/GSI_GridComp/setupps.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupps.f90
@@ -675,7 +675,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
 !       Set (i,j) indices of guess gridpoint that bound obs location
         call get_ij(mm1,dlat,dlon,my_head%ij,my_head%wij)
 
-        if (fsi_weight .and. jiter==jiterstart) then
+        if (fsi_weight) then
           ! Adjustment to omb residual following FSI
           call fsi_apply_weight(sfactor,'ps',itype,data(ilate,i),data(ilone,i),1000.0_r_kind)
           my_head%res      = sfactor*ddiff

--- a/GEOSaana_GridComp/GSI_GridComp/setupq.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupq.f90
@@ -803,7 +803,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         my_head%dlev= dpres
         call get_ijk(mm1,dlat,dlon,dpres,my_head%ij,my_head%wij)
         
-        if (fsi_weight .and. jiter==jiterstart) then
+        if (fsi_weight) then
           ! Adjustment to omb residual following FSI
           call fsi_apply_weight(sfactor,'q',itype,data(ilate,i),data(ilone,i),presq)
           my_head%res    = sfactor*ddiff

--- a/GEOSaana_GridComp/GSI_GridComp/setuprad.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setuprad.f90
@@ -1952,7 +1952,7 @@ contains
                     iii=iii+1
 
                     ! Adjustment to omb residual following FSI
-                    if (fsi_weight .and. jiter==jiterstart) then
+                    if (fsi_weight) then
                        call fsi_apply_weight(sfactor,trim(dplat(is)),trim(obstype), &
                                              ich(ii),cenlat,cenlon)
                        my_head%res(iii)= sfactor*tbc(ii)        !  evecs(R)*[obs-ges innovation]
@@ -2722,6 +2722,7 @@ contains
                  call nc_diag_metadata("Emissivity",                            sngl(emissivity(ich_diag(i)))     )           ! surface emissivity
                  call nc_diag_metadata("Weighted_Lapse_Rate",                   sngl(tlapchn(ich_diag(i)))        )           ! stability index
                  call nc_diag_metadata("dTb_dTs",                               sngl(ts(ich_diag(i)))             )           ! d(Tb)/d(Ts)
+                 call nc_diag_metadata("ascending_flag",                        sngl(node)                        )           !  ascending/decending flag
 
                  call nc_diag_metadata("BC_Constant",                           sngl(predbias(1,ich_diag(i)))      )             ! constant bias correction term
                  call nc_diag_metadata("BC_Scan_Angle",                         sngl(predbias(2,ich_diag(i)))      )             ! scan angle bias correction term

--- a/GEOSaana_GridComp/GSI_GridComp/setupt.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupt.f90
@@ -1065,7 +1065,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         my_head%dlev= dpres
         call get_ijk(mm1,dlat,dlon,dpres,my_head%ij,my_head%wij)
 
-        if (fsi_weight .and. jiter==jiterstart) then
+        if (fsi_weight) then
           ! Adjustment to omb residual following FSI
           call fsi_apply_weight(sfactor,'t',itype,data(ilate,i),data(ilone,i),prest)
           my_head%res     = sfactor*ddiff

--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -1304,7 +1304,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            my_head%wij(j)=factw*my_head%wij(j)
         end do
 
-        if (fsi_weight .and. jiter==jiterstart) then
+        if (fsi_weight) then
           ! Adjustment to omb residual following FSI
           call fsi_apply_weight(sfactor,'wnd',itype,data(ilate,i),data(ilone,i),presw)
           my_head%ures=sfactor*dudiff


### PR DESCRIPTION
FSI weights are to be applied (when applicable) at all outer loops. This is a feature not presently employed in the default configuration so the changes here affect nothing.