### PR TITLE
Add settings for consistent JEDI comp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+29Apr2025:
+- add settings to allow proper comparison with JEDI.
+
 02Apr2025:
 - Revisions to original FSI implemetation:
    o apply it every outer iteration

--- a/GEOSaana_GridComp/GSI_GridComp/etc/CMakeLists.txt
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/CMakeLists.txt
@@ -92,6 +92,8 @@ set (etc_other_files
    gsi.rc.tmpl
    gsi_sens.rc.tmpl
    gsidiags.rc
+   jedi_gsi.rc.tmpl
+   jedi_gsi_sens.rc.tmpl
    obs.rc.tmpl
    )
 install (

--- a/GEOSaana_GridComp/GSI_GridComp/etc/jedi_gsi.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/jedi_gsi.rc.tmpl
@@ -1,0 +1,252 @@
+ &SETUP
+   miter=1,niter(1)=@NITER1,niter(2)=@NITER2,
+   niter_no_qc(1)=999,niter_no_qc(2)=999,
+   write_diag(1)=.true.,write_diag(2)=.true.,write_diag(3)=.true.,
+!--gencode=82,qoption=2,pseudo_q2=.true.,
+!--factqmin=0.005,factqmax=0.005,deltim=300,
+   gencode=82,qoption=1,
+   factqmin=0.8,factqmax=1.2,deltim=300,
+   ifact10=0,
+   use_prepb_satwnd=>>>USE_PREPB_SATWND<<<,
+   ec_amv_qc=.false.,
+   diag_version=30303,
+   iguess=-1,
+   id_drifter=.true.,
+   id_ship=.false.,
+   tzr_qc=1,
+   ta2tb=.false.,
+   oneobtest=.false.,retrieval=.false.,
+   biascor=-0.10,bcoption=0,diurnalbc=1.0,
+   crtm_coeffs_path="CRTM_Coeffs/",
+   print_diag_pcg=.false.,
+   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=55.,lgpsbnd_revint=.true.,
+   commgpstop=45.,spiregpserrinf=2.,
+   use_sp_eqspace=.true.,
+   lbicg=.true.,lcongrad=.false.,ltlint=.true.,
+!  lsqrtb=.true.,lcongrad=.false.,ltlint=.true.,
+@4DHYB l4densvar=.true.,nmn_obsbin=@VAROBSBIN,iwrtinc=@IWRTINC,thin4d=.true.,
+   iorthomax=100,
+   ltcost=.true.,
+   ens_nstarthr=3,
+   netcdf_diag=.true.,wrtgeovals=.false.,
+@RADBC   newpc4pred=.true.,adp_anglebc=.true.,angord=4,
+@RADBC   passive_bc=.true.,use_edges=.false.,
+@RADBC   diag_precon=.true.,step_start=1.e-3,emiss_bc=.true.,
+   lrun_subdirs=.false.,
+ /
+ &GRIDOPTS
+   JCAP=@JCAP,NLAT=@GSINLAT,NLON=@GSINLON,nsig=@NSIG,
+   regional=.false.,
+   nvege_type=20,
+ /
+ &BKGERR
+   vs=0.6,
+   hzscl=0.588,1.25,2.0,
+   hswgt=0.45,0.3,0.25,
+   bw=0.0,norsp=4,
+   bkgv_flowdep=.false.,bkgv_rewgtfct=1.5,
+   fpsproj=.true.,
+   adjustozvar=.true.,
+   bkgv_write=.false.,
+ /
+ &ANBKGERR
+   anisotropic=.false.,
+ /
+ &JCOPTS
+!  ljcpdry=@JCPDRY,bamp_jcpdry=2.5e7,
+   ljcpdry=.false.,bamp_jcpdry=2.5e7,
+ /
+ &STRONGOPTS
+!  tlnmc_option=@TLNMC,nstrong=1,nvmodes_keep=24,period_max=6.,period_width=1.5,
+   tlnmc_option=0,nstrong=1,nvmodes_keep=24,period_max=6.,period_width=1.5,
+   baldiag_full=.true.,baldiag_inc=.true.,
+ /
+ &OBSQC
+   dfact=0.75,dfact1=3.0,noiqc=.false.,oberrflg=.true.,c_varqc=0.02,blacklst=.true.,
+   use_poq7=.true.,qc_noirjaco3=.false.,qc_satwnds=.false.,cld_det_dec2bin=.true.,
+   half_goesr_err=.false.,max_tail=15000,
+!  tcp_ermin=0.75,tcp_ermax=0.75,
+   >>>AIRCFT_BIAS<<<
+ /
+ &OBS_INPUT
+   dmesh(1)=145.0,dmesh(2)=150.0,dmesh(3)=180.0,time_window_max=3.0,
+ /
+OBS_INPUT::
+!  dfile          dtype       dplat       dsis                  dval    dthin  dsfcalc  obsclass
+   prepbufr       ps          null        ps                    0.0     0      0        ncep_prep_bufr
+   prepbufr       t           null        t                     0.0     0      0        ncep_prep_bufr
+   prepbufr_profl t           prof        t                     0.0     0      0        ncep_acftpfl_bufr
+   prepbufr       q           null        q                     0.0     0      0        ncep_prep_bufr
+   prepbufr       uv          null        uv                    0.0     0      0        ncep_prep_bufr
+   prepbufr_profl uv          prof        uv                    0.0     0      0        ncep_acftpfl_bufr
+   prepbufr       spd         null        spd                   0.0     0      0        ncep_prep_bufr
+   radarbufr      rw          null        rw                    0.0     0      0        ncep_radar_bufr
+   prepbufr       dw          null        dw                    0.0     0      0        ncep_prep_bufr
+   mlstbufr       t           aura        t                     1.0     0      0        gmao_mlst_bufr
+!! prepbufr       sst         null        sst                   0.0     0      0        ncep_prep_bufr
+   modsbufr       sst         mods        sst                   0.0     0      0        to_be_done
+   prepbufr       pw          null        pw                    0.0     0      0        ncep_prep_bufr
+   preprscat      uv          null        uv                    0.0     0      0        rscat_bufr
+   gpsrobufr      gps_bnd     null        gps                   0.0     0      0        ncep_gpsro_bufr
+   gpsrocombufr   gps_bnd     null        gps                   0.0     0      0        ncep_gpsro_com_bufr
+   ssmirrbufr     pcp_ssmi    dmsp        pcp_ssmi              0.0     0      0        ncep_spssmi_bufr
+   tmirrbufr      pcp_tmi     trmm        pcp_tmi               0.0     0      0        ncep_sptrmm_bufr
+   sbuvbufr       sbuv2       n16         sbuv8_n16             0.0     0      0        ncep_osbuv_bufr
+   sbuvbufr       sbuv2       n17         sbuv8_n17             0.0     0      0        ncep_osbuv_bufr
+   sbuvbufr       sbuv2       n18         sbuv8_n18             0.0     0      0        ncep_osbuv_bufr
+   omibufr        omi         aura        omi_aura              0.0     2      0        ncep_aura_omi_bufr
+   ompsnmbufr     ompsnm      npp         ompsnm_npp            0.0     2      0        npp_ompsnm_bufr
+   ompsnpbufr     ompsnp      npp         ompsnp_npp            0.0     0      0        npp_ompsnp_bufr
+   ompsnpnc       ompsnpnc    npp         ompsnpnc_npp          0.0     0      0        npp_ompsnp_nc
+!  NOomibufr      omi         aura        omi_aura              0.0     2      0        test
+   hirs2bufr      hirs2       n14         hirs2_n14             0.0     1      0        ncep_1bhrs2_bufr
+   hirs3bufr      hirs3       n16         hirs3_n16             0.0     1      0        ncep_1bhrs3_bufr
+   hirs3bufr      hirs3       n17         hirs3_n17             0.0     1      0        ncep_1bhrs3_bufr
+   hirs4bufr      hirs4       n18         hirs4_n18             0.0     1      0        ncep_1bhrs4_bufr
+   hirs4bufr      hirs4       metop-a     hirs4_metop-a         0.0     1      0        ncep_1bhrs4_bufr
+!  gsndrbufr      sndr        g11         sndr_g11              0.0     1      0        test
+!  gsndrbufr      sndr        g12         sndr_g12              0.0     1      0        test
+!  gimgrbufr      goes_img    g11         imgr_g11              0.0     1      0        test
+!  gimgrbufr      goes_img    g12         imgr_g12              0.0     1      0        test
+   airsbufr       airs        aqua        airs_aqua             0.0     3      0        disc_airs_bufr
+!  msubufr        msu         n14         msu_n14               0.0     1      0        test
+   amsuabufr      amsua       n15         amsua_n15             0.0     1      0        ncep_1bamua_bufr
+   amsuabufr      amsua       n16         amsua_n16             0.0     1      0        ncep_1bamua_bufr
+   amsuabufr      amsua       n17         amsua_n17             0.0     1      0        ncep_1bamua_bufr
+   amsuabufr      amsua       n18         amsua_n18             0.0     1      0        ncep_1bamua_bufr
+   amsuabufr      amsua       metop-a     amsua_metop-a         0.0     1      0        ncep_1bamua_bufr
+!  airsbufr       amsua       aqua        amsua_aqua            0.0     1      0        ncep_airs_bufr
+   dummbufr       amsua       aqua        amsua_aqua            0.0     1      0        test
+   amsubbufr      amsub       n15         amsub_n15             0.0     1      0        ncep_1bamub_bufr
+   amsubbufr      amsub       n16         amsub_n16             0.0     1      0        ncep_1bamub_bufr
+   amsubbufr      amsub       n17         amsub_n17             0.0     1      0        ncep_1bamub_bufr
+   mhsbufr        mhs         n18         mhs_n18               0.0     1      0        ncep_mhs_bufr
+   mhsbufr        mhs         metop-a     mhs_metop-a           0.0     1      0        ncep_mhs_bufr
+!  ssmitbufr      ssmi        f13         ssmi_f13              0.0     1      0        test
+!  ssmitbufr      ssmi        f14         ssmi_f14              0.0     1      0        test
+!  ssmitbufr      ssmi        f15         ssmi_f15              0.0     1      0        test
+   amsrebufr      amsre_low   aqua        amsre_aqua            0.0     1      0        ncep_amsre_bufr
+   amsrebufr      amsre_mid   aqua        amsre_aqua            0.0     1      0        ncep_amsre_bufr
+   amsrebufr      amsre_hig   aqua        amsre_aqua            0.0     1      0        ncep_amsre_bufr
+!  amsregmao      amsre       aqua        amsre_aqua            0.0     1      0        gmao_amsre_bufr
+!  ssmisbufr      ssmis_las   f16         ssmis_f16             0.0     1      0        test
+!  ssmisbufr      ssmis_uas   f16         ssmis_f16             0.0     1      0        test
+!  ssmisbufr      ssmis_img   f16         ssmis_f16             0.0     1      0        test
+!  ssmisbufr      ssmis_env   f16         ssmis_f16             0.0     1      0        test
+   ssmisbufr      ssmis       f16         ssmis_f16             0.0     1      0        ncep_ssmis_bufr
+   ssmisbufr      ssmis       f17         ssmis_f17             0.0     1      0        ncep_ssmis_bufr
+   ssmisbufr      ssmis       f18         ssmis_f18             0.0     1      0        ncep_ssmis_bufr
+   gsnd1bufr      sndrd1      g12         sndrD1_g12            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd2      g12         sndrD2_g12            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd3      g12         sndrD3_g12            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd4      g12         sndrD4_g12            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd1      g11         sndrD1_g11            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd2      g11         sndrD2_g11            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd3      g11         sndrD3_g11            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd4      g11         sndrD4_g11            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd1      g13         sndrD1_g13            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd2      g13         sndrD2_g13            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd3      g13         sndrD3_g13            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd4      g13         sndrD4_g13            0.0     1      0        ncep_goesfv_bufr
+   iasibufr       iasi        metop-a     iasi_metop-a          0.0     3      0        ncep_mtiasi_bufr
+!  gomebufr       gome        metop-a     gome_metop-a          0.0     2      0        test
+!  mlsoz          o3lev       aura        mls_aura_ozlv         0.0     0      0        test
+!  mlsozbufr      o3lev       aura        o3lev_aura            0.0     0      0        test
+!  ompslpgnc      ompslpnc    npp         ompslpnc_npp          1.0     0      0        ompslpnc_nc
+! NOTE: careful not to have both npp_ompslp_nc and r21c_npp_ompslp_nc in obsclass
+!  ompslpnppnc    ompslpnc    npp         ompslpnc_npp          1.0     0      0        npp_ompslp_nc
+!! ompslpnppnc    ompslpnc    npp         ompslpnc_npp          1.0     0      0        r21c_npp_ompslp_nc
+!! ompslpn21nc    ompslpnc    n21         ompslpnc_n21          1.0     0      0        m2scr_n21_ompslp_nc
+   ompslpuvnc     ompslpuv    npp         ompslpuv_npp          1.0     0      0        ompslpuv_nc
+   ompslpvisnc    ompslpvis   npp         ompslpvis_npp         1.0     0      0        ompslpvis_nc
+!  mlsoztext      o3lev       aura        o3lev_aura            0.0     0      0        test
+   amsuabufr      amsua       n19         amsua_n19             0.0     1      0        ncep_1bamua_bufr
+   hirs4bufr      hirs4       n19         hirs4_n19             0.0     1      0        ncep_1bhrs4_bufr
+   mhsbufr        mhs         n19         mhs_n19               0.0     1      0        ncep_mhs_bufr
+   tcvitl         tcp         null        tcp                   0.0     0      0        ncep_tcvitals
+   eosamsuabufr   amsua       aqua        amsua_aqua            0.0     1      0        disc_amsua_bufr
+   sbuvbufr       sbuv2       n19         sbuv8_n19             0.0     0      0        ncep_osbuv_bufr
+   seviribufr     seviri      m08         seviri_m08            0.0     1      0        ncep_sevcsr_bufr
+   seviribufr     seviri      m09         seviri_m09            0.0     1      0        ncep_sevcsr_bufr
+   seviribufr     seviri      m10         seviri_m10            0.0     1      0        ncep_sevcsr_bufr
+   hirs4bufr      hirs4       metop-b     hirs4_metop-b         0.0     1      0        ncep_1bhrs4_bufr
+   amsuabufr      amsua       metop-b     amsua_metop-b         0.0     1      0        ncep_1bamua_bufr
+   mhsbufr        mhs         metop-b     mhs_metop-b           0.0     1      0        ncep_mhs_bufr
+   iasibufr       iasi        metop-b     iasi_metop-b          0.0     3      0        ncep_mtiasi_bufr
+!  gomebufr       gome        metop-b     gome_metop-b          0.0     2      0        test
+   amsuabufr      amsua       metop-c     amsua_metop-c         0.0     1      0        ncep_1bamua_bufr
+   mhsbufr        mhs         metop-c     mhs_metop-c           0.0     1      0        ncep_mhs_bufr
+   iasibufr       iasi        metop-c     iasi_metop-c          0.0     3      0        ncep_mtiasi_bufr
+   atmsbufr       atms        npp         atms_npp              0.0     1      0        ncep_atms_bufr
+   atmsbufr       atms        n20         atms_n20              0.0     1      0        ncep_atms_bufr
+!! atmsbufr       atms        n21         atms_n21              0.0     1      0        ncep_atms_bufr
+   crisfsrbufr    cris-fsr    npp         cris-fsr_npp          0.0     3      0        ncep_crisfsr_bufr
+   crisfsrbufr    cris-fsr    n20         cris-fsr_n20          0.0     3      0        ncep_crisfsr_bufr
+!  crisfsrbufr    cris-fsr    n21         cris-fsr_n21          0.0     3      0        ncep_crisfsr_bufr
+   satwndbufr     uv          null        uv                    0.0     0      0        ncep_satwnd_bufr
+   avcspmbufr     avhrr       n18         avhrr3_n18            0.0     1      0        ncep_avcspm_bufr
+   avcspmbufr     avhrr       n19         avhrr3_n19            0.0     1      0        ncep_avcspm_bufr
+   avcsambufr     avhrr       metop-a     avhrr3_metop-a        0.0     1      0        ncep_avcsam_bufr
+   avcsambufr     avhrr       metop-b     avhrr3_metop-b        0.0     1      0        ncep_avcsam_bufr
+   avcsambufr     avhrr       metop-c     avhrr3_metop-c        0.0     1      0        ncep_avcsam_bufr
+!  omieffbufr     omieff      aura        omieff_aura           0.0     2      0        test
+   omieffnc       omieff      aura        omieff_aura           0.0     2      0        aura_omieff_nc
+   ompsnmeffnc    ompsnmeff   npp         ompsnmeff_npp         0.0     2      0        npp_ompsnmeff_nc
+   gsnd1bufr      sndrd1      g15         sndrD1_g15            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd2      g15         sndrD2_g15            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd3      g15         sndrD3_g15            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd4      g15         sndrD4_g15            0.0     1      0        ncep_goesfv_bufr
+!  tomseffnc      tomseff     nim07       tomseff_nim07         0.0     2      0        test
+!  tomseffnc      tomseff     ep          tomseff_ep            0.0     2      0        test
+!  sbuvbufr       sbuv2       nim07       sbuv8_nim07           0.0     0      0        test
+   mlsnc          mls55       aura        mls55_aura            0.0     0      0        mls_nrt_nc
+   oscatbufr      uv          null        uv                    0.0     0      0        ncep_oscat_bufr
+!  tmibufr        tmi         trmm        tmi_trmm              0.0     1      0        gmao_tmi_bufr
+   gmibufr        gmi         gpm         gmi_gpm               0.0     1      0        gmao_gmi_bufr
+   amsr2bufr      amsr2       gcom-w1     amsr2_gcom-w1         0.0     1      0        gmao_amsr2_bufr
+! The following needs to be set for oneob-test:
+!  prepqc         dummy       dummy       dummy                 1.0     1      0        test
+::
+ &SUPEROB_RADAR
+ /
+ &LAG_DATA
+! lag_accur=1e-6,
+! infile_lag='inistate_lag.dat',
+! lag_stepduration=900.,
+! lag_nmax_bal=100,
+! lag_vorcore_stderr_a=2e3,
+! lag_vorcore_stderr_b=0,
+ /
+ &HYBRID_ENSEMBLE
+   l_hyb_ens=@L_HYB_ENS,n_ens=32,beta_s0=0.25,generate_ens=.false.,uv_hyb_ens=.true.,
+   s_ens_h=800.,s_ens_v=-0.5,
+   jcap_ens=@ENS_JCAP,nlat_ens=@ENS_GSINLAT,nlon_ens=@ENS_GSINLON,aniso_a_en=.false.,
+   jcap_ens_test=@ENS_JCAP,
+   oz_univ_static=.true.,
+!  sst_staticB=.false.,
+!  use_localization_grid=.true.,
+   readin_localization=.true.,
+   readin_beta=.true.,
+   use_gfs_ens=.false.,
+   eqspace_ensgrid=.true.,
+!  write_ens_sprd=.true.,
+!  bens_recenter=.true.,
+!  upd_ens_spread=.true.,
+!  upd_ens_localization=.true.,
+ /
+ &RAPIDREFRESH_CLDSURF
+!  dfi_radar_latent_heat_time_period=30.0,
+ /
+ &SINGLEOB_TEST
+!  maginnov=0.1,magoberr=0.1,oneob_type='t',
+!  oblat=45.,oblon=180.,obpres=1000.,obdattim=2004041512,
+!  obhourset=0.,
+ /
+ &CHEM
+ /
+ &NST
+ nst_gsi=0,
+ /
+ &FSI
+ fsi_weight=.false.,
+ /

--- a/GEOSaana_GridComp/GSI_GridComp/etc/jedi_gsi_sens.rc.tmpl
+++ b/GEOSaana_GridComp/GSI_GridComp/etc/jedi_gsi_sens.rc.tmpl
@@ -1,0 +1,263 @@
+ &SETUP
+   miter=>>>MITER<<<,niter(1)=@NITER1,niter(2)=@NITER2,
+   niter_no_qc(1)=999,niter_no_qc(2)=999,
+   write_diag(1)=>>>GSIWRTDIAG1<<<,write_diag(2)=>>>GSIWRTDIAG2<<<,write_diag(3)=>>>GSIWRTDIAG3<<<,
+   jiterstart=>>>JITERSTART<<<,jiterend=>>>JITEREND<<<,
+!--gencode=82,qoption=2,pseudo_q2=.true.,
+!--factqmin=0.005,factqmax=0.005,deltim=300,
+   gencode=82,qoption=1,
+   factqmin=0.8,factqmax=1.2,deltim=300,
+   ifact10=0,
+   use_prepb_satwnd=>>>USE_PREPB_SATWND<<<,
+   ec_amv_qc=.false.,
+   diag_version=30303,
+   iguess=-1,
+   id_drifter=.true.,
+   id_ship=.false.,
+   tzr_qc=1,
+   ta2tb=.false.,
+   oneobtest=.false.,retrieval=.false.,
+   biascor=-0.10,bcoption=0,diurnalbc=1.0,
+   crtm_coeffs_path="CRTM_Coeffs/",
+   print_diag_pcg=.false.,
+   use_compress=.true.,nsig_ext=@NLEV_EXT,gpstop=55.,lgpsbnd_revint=.true.,
+   commgpstop=45.,spiregpserrinf=2.,
+   use_sp_eqspace=.true.,
+!  l4dvar=@L4DVAR,nhr_assimilation=@VARWINDOW,
+@4DHYB l4densvar=.true.,thin4d=.true.,
+   nmn_obsbin=@VAROBSBIN,
+   idmodel=.true.,
+!--iwrtinc=1,
+   lbicg=.true.,lcongrad=.false.,ltlint=.true.,
+   iorthomax=100,
+   lobsensmin=.true.,lobsensadj=.false.,iobsconv=0,lsensrecompute=.true.,
+   lobsensincr=.false.,lobsensjb=.false.,lobsensfc=.true.,
+   lobsdiagsave=.true.,
+   ens_nstarthr=3,
+   tau_fcst=-1,
+@RADBC   newpc4pred=.true.,adp_anglebc=.true.,angord=4,
+@RADBC   passive_bc=.true.,use_edges=.false.,
+@RADBC   diag_precon=.true.,step_start=1.e-3,emiss_bc=.true.,
+   lrun_subdirs=.false.,
+ /
+ &GRIDOPTS
+   JCAP=@JCAP,NLAT=@GSINLAT,NLON=@GSINLON,nsig=@NSIG,
+   regional=.false.,
+   nvege_type=20,
+ /
+ &BKGERR
+   vs=0.6,
+   hzscl=0.588,1.25,2.0,
+   hswgt=0.45,0.3,0.25,
+   bw=0.0,norsp=4,
+   bkgv_flowdep=.false.,bkgv_rewgtfct=1.5,
+   fpsproj=.true.,
+   adjustozvar=.true.,
+ /
+ &ANBKGERR
+   anisotropic=.false.,
+ /
+ &JCOPTS
+   ljcpdry=.false.,bamp_jcpdry=2.5e7,
+ /
+ &STRONGOPTS
+!  tlnmc_option=@TLNMC,nstrong=1,nvmodes_keep=24,period_max=6.,period_width=1.5,
+   tlnmc_option=0,nstrong=1,nvmodes_keep=24,period_max=6.,period_width=1.5,
+   baldiag_full=.true.,baldiag_inc=.true.,
+ /
+ &OBSQC
+   dfact=0.75,dfact1=3.0,noiqc=.false.,oberrflg=.true.,c_varqc=0.02,blacklst=.true.,
+   use_poq7=.true.,qc_noirjaco3=.false.,qc_satwnds=.false.,cld_det_dec2bin=.true.,
+   half_goesr_err=.false.,max_tail=15000,
+!  tcp_ermin=0.75,tcp_ermax=0.75,
+   >>>AIRCFT_BIAS<<<
+ /
+ &OBS_INPUT
+   dmesh(1)=145.0,dmesh(2)=150.0,dmesh(3)=180.0,time_window_max=3.0,
+ /
+OBS_INPUT::
+!  dfile          dtype       dplat       dsis                  dval    dthin  dsfcalc  obsclass
+   prepbufr       ps          null        ps                    0.0     0      0        ncep_prep_bufr
+   prepbufr       t           null        t                     0.0     0      0        ncep_prep_bufr
+   prepbufr_profl t           null        t                     0.0     0      0        ncep_acftpfl_bufr
+   prepbufr       q           null        q                     0.0     0      0        ncep_prep_bufr
+   prepbufr       uv          null        uv                    0.0     0      0        ncep_prep_bufr
+   prepbufr_profl uv          null        uv                    0.0     0      0        ncep_acftpfl_bufr
+   prepbufr       spd         null        spd                   0.0     0      0        ncep_prep_bufr
+   radarbufr      rw          null        rw                    0.0     0      0        ncep_radar_bufr
+   prepbufr       dw          null        dw                    0.0     0      0        ncep_prep_bufr
+!  mlstbufr       t           aura        t                     1.0     0      0        gmao_mlst_bufr
+!! prepbufr       sst         null        sst                   0.0     0      0        ncep_prep_bufr
+   modsbufr       sst         mods        sst                   0.0     0      0        to_be_done
+   prepbufr       pw          null        pw                    0.0     0      0        ncep_prep_bufr
+   preprscat      uv          null        uv                    0.0     0      0        rscat_bufr
+   gpsrobufr      gps_bnd     null        gps                   0.0     0      0        ncep_gpsro_bufr
+   gpsrocombufr   gps_bnd     null        gps                   0.0     0      0        ncep_gpsro_com_bufr
+   ssmirrbufr     pcp_ssmi    dmsp        pcp_ssmi              0.0     0      0        ncep_spssmi_bufr
+   tmirrbufr      pcp_tmi     trmm        pcp_tmi               0.0     0      0        ncep_sptrmm_bufr
+   sbuvbufr       sbuv2       n16         sbuv8_n16             0.0     0      0        ncep_osbuv_bufr
+   sbuvbufr       sbuv2       n17         sbuv8_n17             0.0     0      0        ncep_osbuv_bufr
+   sbuvbufr       sbuv2       n18         sbuv8_n18             0.0     0      0        ncep_osbuv_bufr
+   omibufr        omi         aura        omi_aura              0.0     2      0        ncep_aura_omi_bufr
+   ompsnmbufr     ompsnm      npp         ompsnm_npp            0.0     2      0        npp_ompsnm_bufr
+   ompsnpbufr     ompsnp      npp         ompsnp_npp            0.0     0      0        npp_ompsnp_bufr
+   ompsnpnc       ompsnpnc    npp         ompsnpnc_npp          0.0     0      0        npp_ompsnp_nc
+!  NOomibufr      omi         aura        omi_aura              0.0     2      0        test
+   hirs2bufr      hirs2       n14         hirs2_n14             0.0     1      0        ncep_1bhrs2_bufr
+   hirs3bufr      hirs3       n16         hirs3_n16             0.0     1      0        ncep_1bhrs3_bufr
+   hirs3bufr      hirs3       n17         hirs3_n17             0.0     1      0        ncep_1bhrs3_bufr
+   hirs4bufr      hirs4       n18         hirs4_n18             0.0     1      0        ncep_1bhrs4_bufr
+   hirs4bufr      hirs4       metop-a     hirs4_metop-a         0.0     1      0        ncep_1bhrs4_bufr
+!  gsndrbufr      sndr        g11         sndr_g11              0.0     1      0        test
+!  gsndrbufr      sndr        g12         sndr_g12              0.0     1      0        test
+!  gimgrbufr      goes_img    g11         imgr_g11              0.0     1      0        test
+!  gimgrbufr      goes_img    g12         imgr_g12              0.0     1      0        test
+   airsbufr       airs        aqua        airs_aqua             0.0     3      0        disc_airs_bufr
+!  msubufr        msu         n14         msu_n14               0.0     1      0        test
+   amsuabufr      amsua       n15         amsua_n15             0.0     1      0        ncep_1bamua_bufr
+   amsuabufr      amsua       n16         amsua_n16             0.0     1      0        ncep_1bamua_bufr
+   amsuabufr      amsua       n17         amsua_n17             0.0     1      0        ncep_1bamua_bufr
+   amsuabufr      amsua       n18         amsua_n18             0.0     1      0        ncep_1bamua_bufr
+   amsuabufr      amsua       metop-a     amsua_metop-a         0.0     1      0        ncep_1bamua_bufr
+!  airsbufr       amsua       aqua        amsua_aqua            0.0     1      0        ncep_airs_bufr
+   dummbufr       amsua       aqua        amsua_aqua            0.0     1      0        test
+   amsubbufr      amsub       n15         amsub_n15             0.0     1      0        ncep_1bamub_bufr
+   amsubbufr      amsub       n16         amsub_n16             0.0     1      0        ncep_1bamub_bufr
+   amsubbufr      amsub       n17         amsub_n17             0.0     1      0        ncep_1bamub_bufr
+   mhsbufr        mhs         n18         mhs_n18               0.0     1      0        ncep_mhs_bufr
+   mhsbufr        mhs         metop-a     mhs_metop-a           0.0     1      0        ncep_mhs_bufr
+!  ssmitbufr      ssmi        f13         ssmi_f13              0.0     1      0        test
+!  ssmitbufr      ssmi        f14         ssmi_f14              0.0     1      0        test
+!  ssmitbufr      ssmi        f15         ssmi_f15              0.0     1      0        test
+   amsrebufr      amsre_low   aqua        amsre_aqua            0.0     1      0        ncep_amsre_bufr
+   amsrebufr      amsre_mid   aqua        amsre_aqua            0.0     1      0        ncep_amsre_bufr
+   amsrebufr      amsre_hig   aqua        amsre_aqua            0.0     1      0        ncep_amsre_bufr
+!  amsregmao      amsre       aqua        amsre_aqua            0.0     1      0        gmao_amsre_bufr
+!  ssmisbufr      ssmis_las   f16         ssmis_f16             0.0     1      0        test
+!  ssmisbufr      ssmis_uas   f16         ssmis_f16             0.0     1      0        test
+!  ssmisbufr      ssmis_img   f16         ssmis_f16             0.0     1      0        test
+!  ssmisbufr      ssmis_env   f16         ssmis_f16             0.0     1      0        test
+   ssmisbufr      ssmis       f16         ssmis_f16             0.0     1      0        ncep_ssmis_bufr
+   ssmisbufr      ssmis       f17         ssmis_f17             0.0     1      0        ncep_ssmis_bufr
+   ssmisbufr      ssmis       f18         ssmis_f18             0.0     1      0        ncep_ssmis_bufr
+   gsnd1bufr      sndrd1      g12         sndrD1_g12            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd2      g12         sndrD2_g12            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd3      g12         sndrD3_g12            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd4      g12         sndrD4_g12            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd1      g11         sndrD1_g11            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd2      g11         sndrD2_g11            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd3      g11         sndrD3_g11            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd4      g11         sndrD4_g11            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd1      g13         sndrD1_g13            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd2      g13         sndrD2_g13            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd3      g13         sndrD3_g13            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd4      g13         sndrD4_g13            0.0     1      0        ncep_goesfv_bufr
+   iasibufr       iasi        metop-a     iasi_metop-a          0.0     3      0        ncep_mtiasi_bufr
+!  gomebufr       gome        metop-a     gome_metop-a          0.0     2      0        test
+!  mlsoz          o3lev       aura        mls_aura_ozlv         0.0     0      0        test
+!  mlsozbufr      o3lev       aura        o3lev_aura            0.0     0      0        test
+!  ompslpgnc      ompslpnc    npp         ompslpnc_npp          1.0     0      0        ompslpnc_nc
+! NOTE: careful not to have both npp_ompslp_nc and r21c_npp_ompslp_nc in obsclass
+!  ompslpnppnc    ompslpnc    npp         ompslpnc_npp          1.0     0      0        npp_ompslp_nc
+!! ompslpnppnc    ompslpnc    npp         ompslpnc_npp          1.0     0      0        r21c_npp_ompslp_nc
+!! ompslpn21nc    ompslpnc    n21         ompslpnc_n21          1.0     0      0        m2scr_n21_ompslp_nc
+   ompslpuvnc     ompslpuv    npp         ompslpuv_npp          1.0     0      0        ompslpuv_nc
+   ompslpvisnc    ompslpvis   npp         ompslpvis_npp         1.0     0      0        ompslpvis_nc
+!  mlsoztext      o3lev       aura        o3lev_aura            0.0     0      0        test
+   amsuabufr      amsua       n19         amsua_n19             0.0     1      0        ncep_1bamua_bufr
+   hirs4bufr      hirs4       n19         hirs4_n19             0.0     1      0        ncep_1bhrs4_bufr
+   mhsbufr        mhs         n19         mhs_n19               0.0     1      0        ncep_mhs_bufr
+   tcvitl         tcp         null        tcp                   0.0     0      0        ncep_tcvitals
+   eosamsuabufr   amsua       aqua        amsua_aqua            0.0     1      0        disc_amsua_bufr
+   sbuvbufr       sbuv2       n19         sbuv8_n19             0.0     0      0        ncep_osbuv_bufr
+   seviribufr     seviri      m08         seviri_m08            0.0     1      0        ncep_sevcsr_bufr
+   seviribufr     seviri      m09         seviri_m09            0.0     1      0        ncep_sevcsr_bufr
+   seviribufr     seviri      m10         seviri_m10            0.0     1      0        ncep_sevcsr_bufr
+   hirs4bufr      hirs4       metop-b     hirs4_metop-b         0.0     1      0        ncep_1bhrs4_bufr
+   amsuabufr      amsua       metop-b     amsua_metop-b         0.0     1      0        ncep_1bamua_bufr
+   mhsbufr        mhs         metop-b     mhs_metop-b           0.0     1      0        ncep_mhs_bufr
+   iasibufr       iasi        metop-b     iasi_metop-b          0.0     3      0        ncep_mtiasi_bufr
+!  gomebufr       gome        metop-b     gome_metop-b          0.0     2      0        test
+   amsuabufr      amsua       metop-c     amsua_metop-c         0.0     1      0        ncep_1bamua_bufr
+   mhsbufr        mhs         metop-c     mhs_metop-c           0.0     1      0        ncep_mhs_bufr
+   iasibufr       iasi        metop-c     iasi_metop-c          0.0     3      0        ncep_mtiasi_bufr
+   atmsbufr       atms        npp         atms_npp              0.0     1      0        ncep_atms_bufr
+   atmsbufr       atms        n20         atms_n20              0.0     1      0        ncep_atms_bufr
+!! atmsbufr       atms        n21         atms_n21              0.0     1      0        ncep_atms_bufr
+   crisfsrbufr    cris-fsr    npp         cris-fsr_npp          0.0     3      0        ncep_crisfsr_bufr
+   crisfsrbufr    cris-fsr    n20         cris-fsr_n20          0.0     3      0        ncep_crisfsr_bufr
+!  crisfsrbufr    cris-fsr    n21         cris-fsr_n21          0.0     3      0        ncep_crisfsr_bufr
+   satwndbufr     uv          null        uv                    0.0     0      0        ncep_satwnd_bufr
+   avcspmbufr     avhrr       n18         avhrr3_n18            0.0     1      0        ncep_avcspm_bufr
+   avcspmbufr     avhrr       n19         avhrr3_n19            0.0     1      0        ncep_avcspm_bufr
+   avcsambufr     avhrr       metop-a     avhrr3_metop-a        0.0     1      0        ncep_avcsam_bufr
+   avcsambufr     avhrr       metop-b     avhrr3_metop-b        0.0     1      0        ncep_avcsam_bufr
+   avcsambufr     avhrr       metop-c     avhrr3_metop-c        0.0     1      0        ncep_avcsam_bufr
+!  omieffbufr     omieff      aura        omieff_aura           0.0     2      0        test
+   omieffnc       omieff      aura        omieff_aura           0.0     2      0        aura_omieff_nc
+   ompsnmeffnc    ompsnmeff   npp         ompsnmeff_npp         0.0     2      0        npp_ompsnmeff_nc
+   gsnd1bufr      sndrd1      g15         sndrD1_g15            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd2      g15         sndrD2_g15            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd3      g15         sndrD3_g15            0.0     1      0        ncep_goesfv_bufr
+   gsnd1bufr      sndrd4      g15         sndrD4_g15            0.0     1      0        ncep_goesfv_bufr
+!  tomseffnc      tomseff     nim07       tomseff_nim07         0.0     2      0        test
+!  tomseffnc      tomseff     ep          tomseff_ep            0.0     2      0        test
+!  sbuvbufr       sbuv2       nim07       sbuv8_nim07           0.0     0      0        test
+   mlsnc          mls55       aura        mls55_aura            0.0     0      0        mls_nrt_nc
+   oscatbufr      uv          null        uv                    0.0     0      0        ncep_oscat_bufr
+!  tmibufr        tmi         trmm        tmi_trmm              0.0     1      0        gmao_tmi_bufr
+   gmibufr        gmi         gpm         gmi_gpm               0.0     1      0        gmao_gmi_bufr
+   amsr2bufr      amsr2       gcom-w1     amsr2_gcom-w1         0.0     1      0        gmao_amsr2_bufr
+! The following needs to be set for oneob-test:
+!  prepqc         dummy       dummy       dummy                 1.0     1      0        test
+::
+ &SUPEROB_RADAR
+ /
+ &LAG_DATA
+! lag_accur=1e-6,
+! infile_lag='inistate_lag.dat',
+! lag_stepduration=900.,
+! lag_nmax_bal=100,
+! lag_vorcore_stderr_a=2e3,
+! lag_vorcore_stderr_b=0,
+ /
+ &HYBRID_ENSEMBLE
+   l_hyb_ens=@L_HYB_ENS,n_ens=32,beta_s0=0.25,generate_ens=.false.,uv_hyb_ens=.true.,
+   s_ens_h=800.,s_ens_v=-0.5,
+   jcap_ens=@ENS_JCAP,nlat_ens=@ENS_GSINLAT,nlon_ens=@ENS_GSINLON,aniso_a_en=.false.,
+   jcap_ens_test=@ENS_JCAP,
+   oz_univ_static=.true.,
+!  sst_staticB=.false.,
+!  use_localization_grid=.true.,
+   readin_localization=.true.,
+   readin_beta=.true.,
+   use_gfs_ens=.false.,
+   eqspace_ensgrid=.true.,
+!  write_ens_sprd=.true.,
+!  bens_recenter=.true.,
+!  upd_ens_spread=.true.,
+!  upd_ens_localization=.true.,
+ /
+ &RAPIDREFRESH_CLDSURF
+!  dfi_radar_latent_heat_time_period=30.0,
+ /
+ &SINGLEOB_TEST
+!  maginnov=0.1,magoberr=0.1,oneob_type='t',
+!  oblat=45.,oblon=180.,obpres=1000.,obdattim=2004041512,
+!  obhourset=0.,
+ /
+ &CHEM
+ /
+ &NST
+ nst_gsi=0,
+ /
+ &FSI
+ fsi_weight=.false.,
+ /
+ &PADVECT
+ advpert=.false.,
+ dt=180.,cfl=.false.,
+ cnstwind_test=.false.,
+ advrate=0.75,
+ backward=.true.,
+ /


### PR DESCRIPTION
Adding settings to allow runs to be fairly compared with JEDI. These are normally not used unless users are exercising the new GEOS-JEDI knob being introduced in the GEOSadas fixture.