### PR TITLE
Feature/jemccurr/highdensityraobs develop

### DIFF
--- a/GEOSaana_GridComp/GSI_GridComp/gsimod.F90
+++ b/GEOSaana_GridComp/GSI_GridComp/gsimod.F90
@@ -36,7 +36,8 @@
   use obsmod, only: netcdf_diag, binary_diag
   use obsmod, only: l_wcp_cwm
   use obsmod, only: wrtgeovals
-  use obsmod, only: thin_flg,superob_flg,smooth_flg,filter_window,pbqc4hd,qcrequired,flag_hr_ua_q
+  use obsmod, only: thin_flg,superob_flg,smooth_flg,filter_window,pbqc4hd,qcrequired,flag_hr_ua_q, &
+          hr_q_cutoff,hr_q_whitelist,hr_save_qc,hr_save_colocated
   use aircraftinfo, only: init_aircraft,hdist_aircraft,aircraft_t_bc_pof,aircraft_t_bc, &
                           aircraft_t_bc_ext,max_tail,biaspredt,upd_aircraft,cleanup_tail
   use obs_sensitivity, only: lobsensfc,lobsensincr,lobsensjb,lsensrecompute, &
@@ -862,7 +863,8 @@
        aircraft_t_bc_pof,aircraft_t_bc,aircraft_t_bc_ext,max_tail,biaspredt,upd_aircraft,cleanup_tail,&
        hdist_aircraft,buddycheck_t,buddydiag_save,vadwnd_l2rw_qc,  &
        pvis,pcldch,scale_cv,estvisoe,estcldchoe,vis_thres,cldch_thres,cld_det_dec2bin,half_goesr_err, &
-       thin_flg,superob_flg,smooth_flg,filter_window,pbqc4hd,qcrequired,flag_hr_ua_q
+       thin_flg,superob_flg,smooth_flg,filter_window,pbqc4hd,qcrequired,flag_hr_ua_q,hr_q_cutoff, &
+       hr_q_whitelist,hr_save_qc,hr_save_colocated
 
 ! OBS_INPUT (controls input data):
 !      dmesh(max(dthin))- thinning mesh for each group

--- a/GEOSaana_GridComp/GSI_GridComp/hdraobmod.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/hdraobmod.f90
@@ -144,6 +144,7 @@ contains
 
   use obsmod, only: iadate,oberrflg,perturb_obs,perturb_fact,ran01dom
   use obsmod, only: blacklst,offtime_data
+  use obsmod, only: hr_q_whitelist,hr_q_cutoff
   use obsmod, only: thin_flg,superob_flg,smooth_flg,filter_window
   use converr,only: etabl
   use converr_ps,only: etabl_ps,isuble_ps,maxsub_ps
@@ -190,6 +191,7 @@ contains
 
   character(80) hdstr,hdstr2,hdstr3,levstr,hdtypestr
   character(80) obstr
+  character(80) sondetypestr
   character(10) date
   character(8) subset
   character(8) c_station_id,id_station
@@ -199,6 +201,7 @@ contains
   character(8) stntype
 
   integer(i_kind) ireadmg,ireadsb
+  integer(i_kind) hr_q_cutoff_cb
   integer(i_kind) lunin,i,maxobs,j,idomsfc,nmsgmax,mxtb
   integer(i_kind) kk,klon1,klat1,klonp1,klatp1
   integer(i_kind) nc,nx,ntread,ncsave
@@ -252,6 +255,7 @@ contains
   real(r_double),dimension(2):: hdr
   real(r_double),dimension(8):: hdr2
   real(r_double),dimension(1):: hdr3
+  real(r_double) typearr
   real(r_double),dimension(1):: hdrtype
   real(r_double),dimension(2,maxlevs):: levdat
   real(r_double),dimension(8,maxlevs):: var_jb,obserr
@@ -273,6 +277,7 @@ contains
   data hdtypestr /'BUHD' /
   data hdstr3 /'HEIT'/
   data obstr  /'LTDS LATDH LONDH GP10 WSPD WDIR TMDB TMDP'/
+  data sondetypestr /'RATP'/
   data levstr /'PRLC GP07'/
   data lunin / 13 /
   data missing/1.e8_r_double/
@@ -547,7 +552,7 @@ contains
            end do
 
            !------------------------------------------------------------------------
-
+           call ufbint(lunin,typearr,1,1,iret,sondetypestr) !check sonde type
            call ufbint(lunin,hdr2,8,1,iret,hdstr2)
            dlat_earth_deg=hdr2(7)
            dlon_earth_deg=hdr2(8)
@@ -1205,6 +1210,13 @@ contains
 
 !             Specific humidity
               else if(qob) then
+                 !throw out if not allowed type and above humidity cutoff
+                 hr_q_cutoff_cb=hr_q_cutoff*0.1_r_kind !convert mb to cb
+                 if ((plevs(k).lt.hr_q_cutoff_cb).and.(NOT(ANY(hr_q_whitelist == nint(typearr)))))then
+                         qqm(k)=typearr+1000
+                         usage=108._r_kind 
+                         write(6,*)id,'setting humidity measurement from RATP: ',typearr,' to monitor'
+                 end if 
                  if((descend).and.(plevs(k)<15))then
                     qqm(k)=12
                     usage=108._r_kind

--- a/GEOSaana_GridComp/GSI_GridComp/obsmod.F90
+++ b/GEOSaana_GridComp/GSI_GridComp/obsmod.F90
@@ -716,7 +716,7 @@ contains
     filter_window=11 ! hdraob smoothing filter window (profile levels)
     pbqc4hd=.true. !hdraob flag for doing QC using prepbufr QC marks 
     qcrequired=.true. !set to true to set hd ascent raobs that cannot be QCed with prepbufr to unused
-    flag_hr_ua_q=.true. !set to false to avoid using prepbufr qc marks indicating q obs above 300 mb 
+    flag_hr_ua_q=.false. !set to false to avoid using prepbufr qc marks indicating q obs above 300 mb 
     hr_q_cutoff=300 !default cutoff for raob humidity assimilation (mb)
     hr_q_whitelist= (/123,124,125,141,142,191,193,70,79,80,81,113,114,152/) !allow q assimilation above cutoff for these sonde types
     hr_save_qc=.true.

--- a/GEOSaana_GridComp/GSI_GridComp/obsmod.F90
+++ b/GEOSaana_GridComp/GSI_GridComp/obsmod.F90
@@ -415,7 +415,10 @@ module obsmod
   public :: destroy_obsmod_vars
   public :: ran01dom,dval_use
   public :: iout_pcp,iout_rad,iadate,iadatemn,write_diag,reduce_diag,oberrflg,bflag,ndat,dthin,dmesh,l_do_adjoint
-  public :: thin_flg,superob_flg,smooth_flg,filter_window,pbqc4hd,qcrequired,flag_hr_ua_q
+  public :: thin_flg,superob_flg,smooth_flg,filter_window,pbqc4hd,qcrequired,flag_hr_ua_q,hr_q_cutoff
+  public :: hr_q_whitelist
+  public :: hr_save_qc
+  public :: hr_save_colocated
   public :: diag_radardbz
   public :: lsaveobsens
   public ::                  iout_cldch, mype_cldch
@@ -571,7 +574,7 @@ module obsmod
   logical         :: missing_to_nopcp
 
   logical, save :: obs_instr_initialized_=.false.
-  logical thin_flg,superob_flg,smooth_flg,pbqc4hd,qcrequired 
+  logical thin_flg,superob_flg,smooth_flg,pbqc4hd,qcrequired
   logical oberrflg,bflag,oberror_tune,perturb_obs,ref_obs,sfcmodel,dtbduv_on,dval_use
   logical blacklst,lobsdiagsave,lobsdiag_allocated,lobskeep,lsaveobsens
   logical lobserver,l_do_adjoint, lobsdiag_forenkf
@@ -589,7 +592,10 @@ module obsmod
   logical l_foreaft_thin
   logical lgpsbnd_revint
   logical flag_hr_ua_q
-
+  integer(i_kind) hr_q_cutoff
+  integer(i_kind) ,dimension(14):: hr_q_whitelist
+  logical hr_save_qc
+  logical hr_save_colocated
   logical l_wcp_cwm
   logical wrtgeovals
 
@@ -711,6 +717,11 @@ contains
     pbqc4hd=.true. !hdraob flag for doing QC using prepbufr QC marks 
     qcrequired=.true. !set to true to set hd ascent raobs that cannot be QCed with prepbufr to unused
     flag_hr_ua_q=.true. !set to false to avoid using prepbufr qc marks indicating q obs above 300 mb 
+    hr_q_cutoff=300 !default cutoff for raob humidity assimilation (mb)
+    hr_q_whitelist= (/123,124,125,141,142,191,193,70,79,80,81,113,114,152/) !allow q assimilation above cutoff for these sonde types
+    hr_save_qc=.true.
+    hr_save_colocated=.true.
+    
 ! moved to create_obsmod_var since l4dvar since before namelist is read
 !   if (l4dvar) then
 !      offtime_data = .true.   ! .true. = ignore difference in obs ref time

--- a/GEOSaana_GridComp/GSI_GridComp/read_prepbufr.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/read_prepbufr.f90
@@ -2507,7 +2507,7 @@ subroutine read_prepbufr(nread,ndata,nodata,infile,obstype,lunout,twindin,sis,&
                     !if model level QM is higher than last pass, set to higher QM
                     !avoid flagging for qm=9 (above 300 mb) if flag_hr_ua_q is false
                     if((qqm(k)>pbqc(ilev+1,i)))then
-                        if(.not.(flag_hr_ua_q.and.(qqm(k).eq.9)))pbqc(ilev+1,i)=qqm(k)
+                        if(.not.((.not.flag_hr_ua_q).and.(qqm(k).eq.9)))pbqc(ilev+1,i)=qqm(k)
                     end if 
 1204                continue
                  end if

--- a/GEOSaana_GridComp/GSI_GridComp/setupps.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupps.f90
@@ -107,7 +107,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   use m_obsdiagNode, only: obsdiagNode_set
   use m_obsdiagNode, only: obsdiagNode_get
   use m_obsdiagNode, only: obsdiagNode_assert
-
+  use obsmod, only: hr_save_qc,hr_save_colocated
   use obsmod, only: rmiss_single,perturb_obs,oberror_tune,&
                     lobsdiagsave,nobskeep,lobsdiag_allocated,&
                     time_offset,lobsdiag_forenkf,ianldate
@@ -192,6 +192,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   real(r_single),allocatable,dimension(:,:)::rdiagbuf
 
   integer(i_kind) ier,ilon,ilat,ipres,ihgt,itemp,id,itime,ikx,iqc,iptrb,ijb,isli
+  integer(i_kind) hr_qc
   integer(i_kind) ier2,iuse,ilate,ilone,istnelv,idomsfc,izz,iprvd,isprvd
   integer(i_kind) ikxx,nn,ibin,ioff,ioff0
   integer(i_kind) i,j,nchar,nreal,ii,jj,k,l,mm1
@@ -202,6 +203,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
 
   logical,dimension(nobs):: luse,muse
   logical,dimension(nobs):: identical_obs
+  real(r_kind),dimension(nobs):: hr_colocated
   integer(i_kind),dimension(nobs):: ioid ! initial (pre-distribution) obs ID
   logical proceed
  
@@ -294,6 +296,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
      muse(i)=nint(data(iuse,i)) <= jiter
   end do
 !  If HD raobs available move prepbufr version to monitor
+  hr_colocated=zero
   if(nhdps > 0)then
      do i=1,nobs
         ikx=nint(data(ikxx,i))
@@ -304,6 +307,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
            stn_loop:do j=1,nhdps
              if(idddd == hdpslist(j))then
                 data(iuse,i)=109._r_kind
+                hr_colocated(i)=one
                 muse(i) = .false.
                 exit stn_loop
              end if
@@ -484,9 +488,11 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
        end do hd_stn_loop
 
        !write pressures to log
-       if ((pbidx>0).and.(pbqcps(2,pbidx)>3)) then !turn off if above threshold
+       hr_qc=pbqcps(2,pbidx)
+       if ((pbidx>0).and.(hr_qc>3)) then !turn off if above threshold
+
            write(6,*),' hd surface pres sanity check: ', pob
-           write(6,*)'setting PS ob at stnidx: ',pbidx,' to unused due to QC val of: ',pbqcps(2,pbidx)
+           write(6,*)'setting PS ob at stnidx: ',pbidx,' to unused due to QC val of: ',hr_qc
            data(iuse,i)=110._r_kind
            muse(i)=.false.
        end if
@@ -1067,6 +1073,7 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
   type(obs_diag),pointer,intent(in):: odiag
 ! Observation class
   character(7),parameter     :: obsclass = '     ps'
+  real(r_single),parameter::     missing = -9.99e9_r_single
   real(r_kind),dimension(miter) :: obsdiag_iuse
            call nc_diag_metadata("Station_ID",              station_id             )
            call nc_diag_metadata("Observation_Class",       obsclass               )
@@ -1122,6 +1129,22 @@ subroutine setupps(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsa
               call nc_diag_data2d("ObsDiagSave_tldepart", odiag%tldepart )
               call nc_diag_data2d("ObsDiagSave_obssen",   odiag%obssen   )             
            endif
+           if (hr_save_qc) then
+              write(6,*)'hr_qc: ',hr_qc
+              if ((itype==119) .and. (npbps>0).and.(iohdraob.eq.0)) then
+                call nc_diag_metadata("high_res_qc", real(hr_qc))
+              else 
+                call nc_diag_metadata("high_res_qc", missing)
+              endif 
+           endif 
+           if ((hr_save_colocated).and.(nhdps>0)) then
+             write(6,*)'hr_colocated: ',hr_colocated(i)
+             if (itype==120) then
+               call nc_diag_metadata("high_res_colocated", real(hr_colocated(i)))
+             else
+               call nc_diag_metadata("high_res_colocated", missing)
+             endif
+           endif  
    
            if (twodvar_regional) then
               call nc_diag_metadata("Dominant_Sfc_Type", data(idomsfc,i)              )

--- a/GEOSaana_GridComp/GSI_GridComp/setupq.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupq.f90
@@ -136,7 +136,8 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   use m_qNode, only: qNode_ich0, qNode_ich0_PBL_Pseudo
   use m_obsLList, only: obsLList
   use obsmod, only: luse_obsdiag,ianldate
-  use obsmod, only: netcdf_diag, binary_diag, dirname,qcrequired
+  use obsmod, only: netcdf_diag, binary_diag, dirname,qcrequired,hr_q_cutoff
+  use obsmod, only: hr_save_qc,hr_save_colocated
   use nc_diag_write_mod, only: nc_diag_init, nc_diag_header, nc_diag_metadata, &
        nc_diag_write, nc_diag_data2d
   use nc_diag_read_mod, only: nc_diag_read_init, nc_diag_read_get_dim, nc_diag_read_close
@@ -231,6 +232,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
   integer(i_kind) i,j,nchar,nreal,ii,l,jj,mm1,itemp,iip
   integer(i_kind) jsig,itype,k,nn,ikxx,iptrb,ibin,ioff,ioff0,icat,ijb,isli
+  integer(i_kind) hr_qc
   integer(i_kind) ier,ilon,ilat,ipres,iqob,id,itime,ikx,iqmax,iqc
   integer(i_kind) ier2,iuse,ilate,ilone,istnelv,iobshgt,istat,izz,iprvd,isprvd
   integer(i_kind) idomsfc,iderivative
@@ -251,6 +253,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   logical ice,proceed
   logical,dimension(nobs):: luse,muse
   logical,dimension(nobs):: identical_obs
+  real(r_kind),dimension(nobs):: hr_colocated
   integer(i_kind),dimension(nobs):: ioid ! initial (pre-distribution) obs ID
 
   logical duplogic
@@ -328,6 +331,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
      muse(i)=nint(data(iuse,i)) <= jiter
   end do
 !  If HD raobs available move prepbufr version to monitor
+  hr_colocated=zero
   if(nhdq > 0)then
      iprev_station=0
      do i=1,nobs
@@ -338,12 +342,14 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            read(station_id,'(i5,3x)',err=1200) idddd
            if(idddd == iprev_station)then
              data(iuse,i)=109._r_kind
+             hr_colocated(i)=one
              muse(i) = .false.
            else
               stn_loop:do j=1,nhdq
                 if(idddd == hdqlist(j))then
                    iprev_station=idddd
                    data(iuse,i)=109._r_kind
+                   hr_colocated(i)=one
                    muse(i) = .false.
                    exit stn_loop
                 end if
@@ -527,6 +533,10 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
      if(.not.in_curbin) cycle
 
+! Hard cutoff for high-res sondes
+!if ((prest.le.hr_q_cutoff).and.((itype==119).or.(itype==118)))cycle
+
+
 ! Interpolate log(ps) & log(pres) at mid-layers to obs locations/times
      call tintrp2a11(ges_ps,psges,dlat,dlon,dtime,hrdifsig,&
           mype,nfldsig)
@@ -577,31 +587,20 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        end do hd_stn_loop
        if(pbidx.gt.0) then!skip qc array search if PB station not found
          pqc_lev=minloc(abs(prsltmp3-prest),DIM=1)
-         if (pbqcq(pqc_lev+1,pbidx)>3) then !turn off if above threshold
+         hr_qc=pbqcq(pqc_lev+1,pbidx)
+         if (hr_qc>3) then !turn off if above threshold
               write(6,*),' layer pres: ',prsltmp3(pqc_lev),'for hd ob pres: ',prest
-              write(6,*)'setting Q ob at stnidx: ',pbidx,' to unused due to QC val of: ',pbqcq(pqc_lev+1,pbidx)
+              write(6,*)'setting Q ob at stnidx: ',pbidx,' to unused due to QC val of: ',hr_qc
               data(iuse,i)=110._r_kind
               muse(i)=.false.
          end if 
-         if (qcrequired.and.(pbqcq(pqc_lev+1,pbidx).eq.0)) then !if qcrequired option then turn off for no QC
+         if (qcrequired.and.(hr_qc.eq.0)) then !if qcrequired option then turn off for no QC
              write(6,*),' layer pres: ',prsltmp3(pqc_lev),'for hd ob pres: ',prest
              write(6,*)'setting Q ob at stnidx: ',pbidx,' to unused due to missing QC'
              data(iuse,i)=111._r_kind
              muse(i)=.false.
          end if  
        end if 
-       !do pqc_lev=2,nsig+1 !iterate over model layer pressure levels at ob location (log pressure)
-       !   if (prsitmp2(pqc_lev)<prest) then
-       !      if (pbqcq(pqc_lev,pbidx)>3) then !turn off if above threshold
-       !            write(6,*),' layer pres: ',prsltmp3(pqc_lev-1),' tripped at: ',prsitmp2(pqc_lev),'for hd ob pres: ',prest
-       !            write(6,*)'setting Q ob at stnidx: ',pbidx,' to unused due to QC val of: ',pbqcq(pqc_lev,pbidx)
-       !            muse(i)=.false.
-       !      else
-       !            write(6,*)'ob above model top'
-       !      end if
-       !      exit
-       !   end if
-       !end do
 1201   continue
        if(iohdraob.ne.0)then
                write(6,*)'WARNING - problem reading hdraob station name: ',hd_rstation_id
@@ -1403,6 +1402,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   type(obs_diag),pointer,intent(in):: odiag
 ! Observation class
   character(7),parameter     :: obsclass = '      q'
+  real(r_single),parameter::     missing = -9.99e9_r_single
   real(r_kind),dimension(miter) :: obsdiag_iuse
 
            call nc_diag_metadata("Station_ID",              station_id             )
@@ -1457,6 +1457,23 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_data2d("ObsDiagSave_nldepart", odiag%nldepart )
               call nc_diag_data2d("ObsDiagSave_tldepart", odiag%tldepart )
               call nc_diag_data2d("ObsDiagSave_obssen",   odiag%obssen   )             
+           endif
+
+           if (hr_save_qc) then 
+             write(6,*)'hr_qc: ',hr_qc
+             if ((itype==119) .and. (npbq>0).and.(iohdraob.eq.0)) then
+               call nc_diag_metadata("high_res_qc", real(hr_qc))
+             else 
+               call nc_diag_metadata("high_res_qc", missing)
+             endif 
+           endif 
+           if ((hr_save_colocated).and.(nhdq>0)) then 
+              write(6,*)'hr_colocated: ',hr_colocated(i)
+              if (itype==120) then 
+                call nc_diag_metadata("high_res_colocated", real(hr_colocated(i)))
+              else 
+                call nc_diag_metadata("high_res_colocated", missing)
+              endif
            endif
 
            if (twodvar_regional) then

--- a/GEOSaana_GridComp/GSI_GridComp/setupt.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupt.f90
@@ -31,6 +31,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
   use obsmod, only: sfcmodel,perturb_obs,oberror_tune,lobsdiag_forenkf,ianldate,&
        lobsdiagsave,nobskeep,lobsdiag_allocated,time_offset,qcrequired
+  use obsmod, only: hr_save_qc,hr_save_colocated
   use obsmod, only: dplat
   use obsmod, only: wrtgeovals
   use obsmod, only: saberTbot,saberTtop
@@ -279,6 +280,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
 
   integer(i_kind) i,j,nchar,nreal,k,ii,iip,jj,l,nn,ibin,idia,idia0,ix,ijb
+  integer(i_kind) hr_qc
   integer(i_kind) mm1,jsig,iqt
   integer(i_kind) itype,msges
   integer(i_kind) ier,ilon,ilat,ipres,itob,id,itime,ikx,iqc,iptrb,icat,ipof,ivvlc,idx,isli
@@ -303,6 +305,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
   logical,dimension(nobs):: luse,muse
   logical,dimension(nobs):: identical_obs
+  real(r_kind),dimension(nobs):: hr_colocated
   integer(i_kind),dimension(nobs):: ioid ! initial (pre-distribution) obs ID
   logical sfctype
   logical iqtflg
@@ -404,7 +407,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   end do
   !  If HD raobs available move prepbufr version to monitor
   !  Usage code set to 109 to simplify identification w ncdiag output
-
+  hr_colocated=zero
   if(nhdt > 0)then
      iprev_station=0
      do i=1,nobs
@@ -415,12 +418,14 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            read(station_id,'(i5,3x)',err=1200) idddd
            if(idddd == iprev_station)then
              data(iuse,i)=109._r_kind
+             hr_colocated(i)=one
              muse(i) = .false.
            else
               stn_loop:do j=1,nhdt
                 if(idddd == hdtlist(j))then
                    iprev_station=idddd
                    data(iuse,i)=109._r_kind
+                   hr_colocated(i)=one
                    muse(i) = .false.
                    exit stn_loop
                 end if
@@ -741,18 +746,21 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        end do hd_stn_loop
        if(pbidx.gt.0)then !skip qc array search if PB station not found
          pqc_lev=minloc(abs(prsltmp4-prest),DIM=1) 
-         if (pbqct(pqc_lev+1,pbidx)>3) then !turn off if above threshold
+         hr_qc=pbqct(pqc_lev+1,pbidx)
+         if (hr_qc>3) then !turn off if above threshold
              write(6,*),' layer pres: ',prsltmp4(pqc_lev),'for hd ob pres: ',prest
-             write(6,*)'setting T ob at stnidx: ',pbidx,' to unused due to QC val of: ',pbqct(pqc_lev+1,pbidx) 
+             write(6,*)'setting T ob at stnidx: ',pbidx,' to unused due to QC val of: ',hr_qc 
              data(iuse,i)=110._r_kind
              muse(i)=.false.
          end if 
-         if (qcrequired.and.(pbqct(pqc_lev+1,pbidx).eq.0)) then !if qcrequired option then turn off for no QC
+         if (qcrequired.and.(hr_qc.eq.0)) then !if qcrequired option then turn off for no QC
              write(6,*),' layer pres: ',prsltmp4(pqc_lev),'for hd ob pres: ',prest
              write(6,*)'setting T ob at stnidx: ',pbidx,' to unused due to missing QC'
              data(iuse,i)=111._r_kind
              muse(i)=.false.
          end if 
+       else
+         hr_qc=-1 !set to negative if matching PB station not found
        end if 
        !do pqc_lev=2,nsig+1 !iterate over model layer pressure levels at ob location (log pressure)
        !   if (prsitmp2(pqc_lev)<prest) then
@@ -1860,6 +1868,23 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        call nc_diag_data2d("ObsDiagSave_nldepart", odiag%nldepart )
        call nc_diag_data2d("ObsDiagSave_tldepart", odiag%tldepart )
        call nc_diag_data2d("ObsDiagSave_obssen",   odiag%obssen   )              
+    endif
+
+    if (hr_save_qc) then
+      write(6,*)'hr_qc: ',hr_qc
+      if ((itype==119) .and.(npbt>0).and.(iohdraob.eq.0)) then
+        call nc_diag_metadata("high_res_qc", real(hr_qc))
+      else 
+        call nc_diag_metadata("high_res_qc", missing)
+      endif 
+    endif 
+    if ((hr_save_colocated).and.(nhdt>0)) then
+      write(6,*)'hr_colocated: ',hr_colocated(i)
+      if (itype==120) then
+        call nc_diag_metadata("high_res_colocated", real(hr_colocated(i)))
+      else
+        call nc_diag_metadata("high_res_colocated", missing)
+      endif
     endif
 
     if (twodvar_regional) then

--- a/GEOSaana_GridComp/GSI_GridComp/setupw.f90
+++ b/GEOSaana_GridComp/GSI_GridComp/setupw.f90
@@ -32,6 +32,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   use obsmod, only: rmiss_single,perturb_obs,oberror_tune,lobsdiag_forenkf,&
        lobsdiagsave,nobskeep,lobsdiag_allocated,&
        time_offset,bmiss,ianldate,qcrequired
+  use obsmod, only: hr_save_qc,hr_save_colocated
   use obsmod, only: dplat
   use obsmod, only: wrtgeovals
   use m_obsNode, only: obsNode
@@ -263,6 +264,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   real(r_single),allocatable,dimension(:,:)::rdiagbuf
 
   integer(i_kind) i,nchar,nreal,k,j,l,ii,itype,ijb
+  integer(i_kind) hr_qc
 ! Variables needed for new polar winds QC based on Log Normalized Vector Departure (LNVD)
   real(r_kind) LNVD_wspd
   real(r_kind) LNVD_omb
@@ -299,6 +301,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   logical z_height,sfc_data
   logical,dimension(nobs):: luse,muse
   logical,dimension(nobs):: identical_obs
+  real(r_kind),dimension(nobs):: hr_colocated
   real,dimension(nobs):: qc_flag
   logical:: muse_u,muse_v
   integer(i_kind),dimension(nobs):: ioid ! initial (pre-distribution) obs ID
@@ -424,6 +427,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
      end if
   end do
 !  If HD raobs available move prepbufr version to monitor
+  hr_colocated=zero
   if(nhduv > 0)then
      iprev_station=0
      do i=1,nobs
@@ -434,12 +438,14 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            read(station_id,'(i5,3x)',err=1200) idddd
            if(idddd == iprev_station)then
              data(iuse,i)=109._r_kind
+             hr_colocated(i)=one
              muse(i) = .false.
            else
               stn_loop:do j=1,nhduv
                 if(idddd == hduvlist(j))then
                    iprev_station=idddd
                    data(iuse,i)=109._r_kind
+                   hr_colocated(i)=one
                    muse(i) = .false.
                    exit stn_loop
                 end if
@@ -718,13 +724,14 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         end do hd_stn_loop
         if(pbidx.gt.0)then !skip qc array search if PB station not found
           pqc_lev=minloc(abs(zges-dpres),DIM=1)
-          if (pbqcuv(pqc_lev+1,pbidx)>3) then
+          hr_qc=pbqcuv(pqc_lev+1,pbidx)
+          if (hr_qc>3) then
              write(6,*),' layer height: ',zges(pqc_lev),'for  hd ob height: ',dpres
-             write(6,*)'setting UV ob at stnidx: ',pbidx,' to unused due to QC val of: ',pbqcuv(pqc_lev+1,pbidx)
+             write(6,*)'setting UV ob at stnidx: ',pbidx,' to unused due to QC val of: ',hr_qc
              data(iuse,i)=110._r_kind
              muse(i)=.false.
           end if  
-          if (qcrequired.and.(pbqcuv(pqc_lev+1,pbidx).eq.0)) then
+          if (qcrequired.and.(hr_qc.eq.0)) then
              write(6,*),' layer height: ',zges(pqc_lev),'for  hd ob height: ',dpres
              write(6,*)'setting UV ob at stnidx: ',pbidx,' to unused due to missing QC'
              data(iuse,i)=111._r_kind
@@ -878,31 +885,20 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         end do hd_stn_loop_pres
         if(pbidx.gt.0)then !skip qc array search if PB station not found
           pqc_lev=minloc(abs(prsltmp3-presw),DIM=1)
-          if (pbqcuv(pqc_lev+1,pbidx)>3) then
+          hr_qc=pbqcuv(pqc_lev+1,pbidx)
+          if (hr_qc>3) then
              write(6,*),' layer pres: ',prsltmp3(pqc_lev),'for hd ob pres: ',presw
-             write(6,*)'setting UV ob at stnidx: ',pbidx,' to unused due to QC val of: ',pbqcuv(pqc_lev+1,pbidx)
+             write(6,*)'setting UV ob at stnidx: ',pbidx,' to unused due to QC val of: ',hr_qc
              data(iuse,i)=110._r_kind
              muse(i)=.false.
           end if 
-          if (qcrequired.and.(pbqcuv(pqc_lev+1,pbidx).eq.0)) then
+          if (qcrequired.and.(hr_qc.eq.0)) then
              write(6,*),' layer pres: ',prsltmp3(pqc_lev),'for hd ob pres: ',presw
              write(6,*)'setting UV ob at stnidx: ',pbidx,' to missing QC'
              data(iuse,i)=111._r_kind
              muse(i)=.false.
           end if
         end if 
-        !do pqc_lev=2,nsig+1 !iterate over model layer pressure levels at ob location (log pressure)
-        !  if (prsitmp2(pqc_lev)<presw) then
-        !     if (pbqcuv(pqc_lev,pbidx)>3) then
-        !           write(6,*),' layer pres: ',prsltmp3(pqc_lev-1),' tripped at: ',prsitmp2(pqc_lev),'for hd ob pres: ',presw
-        !           write(6,*)'setting UV ob at stnidx: ',pbidx,' to unused due to QC val of: ',pbqcuv(pqc_lev,pbidx)
-        !           muse(i)=.false.
-        !     else
-        !           write(6,*)'ob above model top'
-        !     end if
-        !     exit
-        !  end if
-        !end do
 1202    continue
           if(iohdraob.ne.0)then
                write(6,*)'WARNING - problem reading hdraob station name: ',hd_rstation_id
@@ -1910,6 +1906,7 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   type(obs_diag),pointer,intent(in):: udiag,vdiag
 ! Observation class
   character(7),parameter     :: obsclass = '     uv'
+  real(r_single),parameter::     missing = -9.99e9_r_single
   real(r_kind),dimension(miter) :: obsdiag_iuse
 
            call nc_diag_metadata("Station_ID",              station_id             )
@@ -2023,7 +2020,22 @@ subroutine setupw(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_data2d("u_ObsDiagSave_obssen",   udiag%obssen   )
               call nc_diag_data2d("v_ObsDiagSave_obssen",   vdiag%obssen   )
            endif
-
+           if (hr_save_qc) then
+             write(6,*)'hr_qc: ',hr_qc
+             if (((itype==219).or.(itype==218)) .and. (npbuv>0).and.(iohdraob.eq.0)) then
+               call nc_diag_metadata("high_res_qc", real(hr_qc))
+             else 
+               call nc_diag_metadata("high_res_qc", missing)
+             endif 
+           endif 
+           if ((hr_save_colocated).and.(nhduv>0)) then
+             write(6,*)'hr_colocated: ',hr_colocated(i)
+             if (itype==220) then
+               call nc_diag_metadata("high_res_colocated", real(hr_colocated(i)))
+             else
+               call nc_diag_metadata("high_res_colocated", missing)
+             endif 
+           endif
            if (twodvar_regional) then
               call nc_diag_metadata("Model_Terrain",     data(izz,i)                  )
               r_prvstg            = data(iprvd,i)


### PR DESCRIPTION
Several additions and modifications to original pull request for high density raob assimilation.

Improves treatment of pressure level cutoff for the assimilation of specific humidity. New namelist option 'hr_q_cutoff' to allow full specification of cutoff pressure. Minor changes to code to do this in a cleaner way than previous PR.

Adds 'hr_q_whitelist' option to allow certain sonde types to be assimilated above the specified cutoff. This may be useful for allowing in RS41 type sondes for example, which are rated for humidity measurement in low temperature conditions and have available documentation for error statistics. Current implementation here is passing an array of 14 integer values corresponding to sonde types that pass through the cutoff filter. Default set in obsmod is an array of all zeros, users would pass "123,124,125,141,142,191,193,70,79,80,81,113,114,152" in gsi.rc.tmpl to whitelist RS41 types. 

Changes default setting for 'flag_hr_ua_q' to false to avoid carrying over prepbufr flagging of humidity observations above 300 mb. This is preferred when actively using the humidity cutoff feature

Adds two variables to netcdf diag output and corresponding namelist options to write/not write these in diags. 'hr_save_qc' saves prepbufr derived QC values for non-descending high-res obs. 'hr_save_colocated' saves binary array for prepbufr sonde obs indicating colocation/non-colocation with high-res obs. This should speed up transitional JEDI system implementation of high-res data before more permanent pre-filter solutions are ready. 

Recommend using default settings for X experiments in the near term. Results with GEOSIT OSE’s suggest that there are potential benefits from assimilating humidity above 300 mb in combination with profile smoothing, especially in the tropical upper troposphere/lower stratosphere. However doing this with the current smoothing approach requires a trade off with degraded forecast scores in the lower levels and in the northern hemisphere, probably because humidity measurements in the troposphere and stratosphere require different kernel widths for smoothing. Future approaches that limit smoothing to areas above the tropopause or apply separate kernel widths could be more promising. 

Final note - I did a zero diff test against the current develop branch and found identical results for a case not assimilating high-res ob types. 