### PR TITLE
atms coeff upd for CRTM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-24Jul2026:
-- now able to write out ncdiags for specific jiter iteration
-21Jul2026:
-- revise settings of jedi-gsi (closer to actual GSI)
-
-03Feb2026:
-- output ABI tb standard deviation to nc diag file and change water wapor unit from g/kg to kg/kg
+- update to point to version of CRTM w/ fix for atms-n21
 
 ### Fixed
 

--- a/GEOSaana_GridComp/GSI_GridComp/analyzer
+++ b/GEOSaana_GridComp/GSI_GridComp/analyzer
@@ -650,7 +650,7 @@ sub init {
    if ( $ENV{CRTM_COEFFS} ) {
       Assignfn( "$CRTM_COEFFS","CRTM_Coeffs");
    } else {
-      Assignfn( "$fvInput/$myetc/JEDI-CRTM-2.4.1j1-GMAO/Little_Endian","CRTM_Coeffs");
+      Assignfn( "$fvInput/$myetc/JEDI-CRTM-2.4.1j1-GMAO-1/Little_Endian","CRTM_Coeffs");
    }
    Assignfn( "$fvhome/run/prepobs_errtable.global","errtable");
 


### PR DESCRIPTION
Updated to point the version of CRTM coeffs w/ fix for ATMS-N21. (but fix) non-zero diff (intentional).